### PR TITLE
Fix custom config and Archive friendly csv tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ wheels/
 
 .env
 
-table.csv
-logs.json
+*.csv
+*.log

--- a/config.toml
+++ b/config.toml
@@ -1,30 +1,23 @@
-#ETH/USD
+#ETH/USD (these values are for testing purposes)
 [83a7f3d48786ac2667503a61e8c415438ed2922eb86a2906e4ee66d9a2ce4992]
 metric = "percentage"
 alert_threshold = 0.1
-# setting warning to 0 means don't dispute
-warning_threshold = 0.4
-minor_threshold = 0.50
-major_threshold = 0.25
+warning_threshold = 0.25
+minor_threshold = 0.99
+major_threshold = 0.0
 
-#BTC/USD
+#BTC/USD (these values are for testing purposes)
 [a6f013ee236804827b77696d350e9f0ac3e879328f2a3021d473a0b778ad78ac]
 metric = "percentage"
-alert_threshold = 0.5
-warning_threshold = 0.5
-minor_threshold = 0.55
-major_threshold = 0.75
-#TRB/USD
-[5C13CD9C97DBB98F2429C101A2A8150E6C7A0DDAFF6124EE176A3A411067DED0]
-metric = "range"
-alert_threshold = 200
-warning_threshold = 200
-minor_threshold = 700
-major_threshold = 5000
+alert_threshold = 0.05
+warning_threshold = 0.25
+minor_threshold = 0.99
+major_threshold = 0.0
 
-[some_random_query_id]
-metric = "equality"
-alert_threshold = 1.0
-warning_threshold = 0.0
-minor_threshold = 0.0
+#TRB/USD (these values are for testing purposes)
+[5C13CD9C97DBB98F2429C101A2A8150E6C7A0DDAFF6124EE176A3A411067DED0]
+metric = "percentage"
+alert_threshold = 0.05
+warning_threshold = 0.25
+minor_threshold = 0.99
 major_threshold = 0.0

--- a/env.example
+++ b/env.example
@@ -1,5 +1,10 @@
-URI = ws://localhost:26657/websocket
+# URI for node websockets connection
+URI = localhost:26657
+# chain id
 CHAIN_ID=layer-testnet-3
+# Up to 3 discord webhooks for sending alerts
 DISCORD_WEBHOOK_URL_1=""
 DISCORD_WEBHOOK_URL_2=""
 DISCORD_WEBHOOK_URL_3=""
+# Maximum number of rows to store in reports tables
+MAX_TABLE_ROWS=1000000

--- a/lvm.service.example
+++ b/lvm.service.example
@@ -1,0 +1,17 @@
+[Unit]
+Description=Layer Values Monitor Service
+After=network.target
+
+[Service]
+Type=simple
+User=<USERNAME>
+Group=<USERNAME>
+WorkingDirectory=/home/<USERNAME>/layer-values-monitor
+Environment=PATH=/home/<USERNAME>/.local/bin
+Environment=PYTHONPATH=/home/<USERNAME>/layer-values-monitor/.venv
+ExecStart=/bin/bash -c "uv run layer-values-monitor /home/<USERNAME>/layerd <ACCOUNT_NAME> <KEYRING_BACKEND> /home/<USERNAME>/.layer --global-percentage-alert-threshold 0.10" ...
+Restart=always
+RestartSec=60
+
+[Install]
+WantedBy=multi-user.target

--- a/src/layer_values_monitor/constants.py
+++ b/src/layer_values_monitor/constants.py
@@ -1,12 +1,12 @@
 """Constants for the Layer Values Monitor."""
 
-from collections import deque
 import os
-from datetime import datetime, timezone
+from collections import deque
+from datetime import UTC, datetime
 
 DENOM = "loya"
 
 TABLE = deque(maxlen=60)
 CSV_FILE_PATTERN = "table_{timestamp}.csv"
-CURRENT_CSV_FILE = f"table_{int(datetime.now(timezone.utc).timestamp())}.csv"
+CURRENT_CSV_FILE = f"table_{int(datetime.now(UTC).timestamp())}.csv"
 LOGS_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "logs")

--- a/src/layer_values_monitor/constants.py
+++ b/src/layer_values_monitor/constants.py
@@ -5,4 +5,4 @@ from collections import deque
 DENOM = "loya"
 
 TABLE = deque(maxlen=60)
-CSV_FILE = "table.csv"
+CSV_FILE_PATTERN = "table_{timestamp}.csv"

--- a/src/layer_values_monitor/constants.py
+++ b/src/layer_values_monitor/constants.py
@@ -1,8 +1,12 @@
 """Constants for the Layer Values Monitor."""
 
 from collections import deque
+import os
+from datetime import datetime, timezone
 
 DENOM = "loya"
 
 TABLE = deque(maxlen=60)
 CSV_FILE_PATTERN = "table_{timestamp}.csv"
+CURRENT_CSV_FILE = f"table_{int(datetime.now(timezone.utc).timestamp())}.csv"
+LOGS_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "logs")

--- a/src/layer_values_monitor/main.py
+++ b/src/layer_values_monitor/main.py
@@ -70,7 +70,7 @@ async def start() -> None:
         "--global-percentage-major-threshold", default=0.0, type=float, help="Global percentage for a major dispute cat"
     )
     # range
-    parser.add_argument("--global-range-alert-threshold", type=float, help="Global range threshold")
+    parser.add_argument("--global-range-alert-threshold", default=0.0, type=float, help="Global range threshold")
     parser.add_argument(
         "--global-range-warning-threshold", default=0.0, type=float, help="Global range for a warning dispute cat"
     )
@@ -81,15 +81,15 @@ async def start() -> None:
         "--global-range-major-threshold", default=0.0, type=float, help="Global range for a major dispute cat"
     )
     # equality
-    parser.add_argument("--global-equality-alert-threshold", type=bool, help="Global equality threshold")
+    parser.add_argument("--global-equality-alert-threshold", default=False, type=bool, help="Global equality threshold")
     parser.add_argument(
-        "--global-equality-warning-threshold", default=0.0, type=float, help="Global equality for a warning dispute cat"
+        "--global-equality-warning-threshold", default=False, type=bool, help="Global equality for a warning dispute cat"
     )
     parser.add_argument(
-        "--global-equality-minor-threshold", default=0.0, type=float, help="Global equality for a minor dispute cat"
+        "--global-equality-minor-threshold", default=False, type=bool, help="Global equality for a minor dispute cat"
     )
     parser.add_argument(
-        "--global-equality-major-threshold", default=0.0, type=float, help="Global equality for a major dispute cat"
+        "--global-equality-major-threshold", default=False, type=bool, help="Global equality for a major dispute cat"
     )
     args = parser.parse_args()
 

--- a/src/layer_values_monitor/monitor.py
+++ b/src/layer_values_monitor/monitor.py
@@ -176,12 +176,12 @@ async def inspect_reports(
         )
 
         if any(
-            [
-                not metrics.metric,
-                not metrics.alert_threshold,
-                not metrics.warning_threshold,
-                not metrics.minor_threshold,
-                not metrics.major_threshold,
+            x is None for x in [
+                metrics.metric,
+                metrics.alert_threshold,
+                metrics.warning_threshold,
+                metrics.minor_threshold,
+                metrics.major_threshold,
             ]
         ):
             logger.error(f"config for {query_id} not set properly")

--- a/src/layer_values_monitor/utils.py
+++ b/src/layer_values_monitor/utils.py
@@ -2,14 +2,14 @@
 
 import logging
 import os
-from datetime import datetime, timezone
-import pandas as pd
-from dotenv import load_dotenv
+from datetime import UTC, datetime
 
-from layer_values_monitor.constants import TABLE, CSV_FILE_PATTERN, CURRENT_CSV_FILE, LOGS_DIR
+from layer_values_monitor.constants import CSV_FILE_PATTERN, CURRENT_CSV_FILE, LOGS_DIR, TABLE
 from layer_values_monitor.custom_types import GlobalMetric, Metrics
 from layer_values_monitor.threshold_config import ThresholdConfig
 
+import pandas as pd
+from dotenv import load_dotenv
 from pandas import DataFrame
 
 # Load environment variables
@@ -36,7 +36,7 @@ def should_create_new_file() -> bool:
 
 def create_new_csv_file() -> str:
     """Create a new CSV file with current timestamp and return its path."""
-    timestamp = int(datetime.now(timezone.utc).timestamp())
+    timestamp = int(datetime.now(UTC).timestamp())
     new_filename = CSV_FILE_PATTERN.format(timestamp=timestamp)
     new_filepath = os.path.join(LOGS_DIR, new_filename)
     

--- a/src/layer_values_monitor/utils.py
+++ b/src/layer_values_monitor/utils.py
@@ -14,7 +14,7 @@ from pandas import DataFrame
 
 # Load environment variables
 load_dotenv()
-MAX_TABLE_ROWS = int(os.getenv("MAX_TABLE_ROWS", "1000"))  # Default to 1000 if not set
+MAX_TABLE_ROWS = int(os.getenv("MAX_TABLE_ROWS", "100000"))
 
 def get_current_csv_path() -> str:
     """Get the full path to the current CSV file."""

--- a/src/layer_values_monitor/utils.py
+++ b/src/layer_values_monitor/utils.py
@@ -76,11 +76,11 @@ def add_to_table(entry: dict[str, str]) -> None:
     file_date = datetime.fromtimestamp(file_timestamp, timezone.utc)
     
     if current_time.date() > file_date.date():
-        # We're in a new day, use the new file
-        csv_file = current_csv_file
+        # We're in a new day, create and use a new file
+        csv_file = get_current_csv_file()  # This will create a new file with today's timestamp
     else:
-        # Try to get the latest existing file, or use current day's file if none exists
-        csv_file = get_latest_csv_file() or current_csv_file
+        # We're in the same day, use the existing file
+        csv_file = current_csv_file
 
     # Write to the appropriate CSV file
     if os.path.exists(csv_file):

--- a/src/layer_values_monitor/utils.py
+++ b/src/layer_values_monitor/utils.py
@@ -2,12 +2,16 @@
 
 import logging
 import os
+from datetime import datetime, timezone
 
-from layer_values_monitor.constants import CSV_FILE, TABLE
+from layer_values_monitor.constants import TABLE,CSV_FILE_PATTERN
 from layer_values_monitor.custom_types import GlobalMetric, Metrics
 from layer_values_monitor.threshold_config import ThresholdConfig
 
 from pandas import DataFrame
+
+
+logs_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "logs")
 
 
 def get_metric(
@@ -63,9 +67,42 @@ def add_to_table(entry: dict[str, str]) -> None:
     df = DataFrame(TABLE).sort_values(by="TIMESTAMP")
     print(df.to_string(index=False, justify="center"))
 
-    if os.path.exists(CSV_FILE):
+    # Get the current day's CSV file
+    current_csv_file = get_current_csv_file()
+    
+    # Check if we need to switch to a new file (if current time is past midnight UTC)
+    current_time = datetime.now(timezone.utc)
+    file_timestamp = int(os.path.basename(current_csv_file).split("_")[1].split(".")[0])
+    file_date = datetime.fromtimestamp(file_timestamp, timezone.utc)
+    
+    if current_time.date() > file_date.date():
+        # We're in a new day, use the new file
+        csv_file = current_csv_file
+    else:
+        # Try to get the latest existing file, or use current day's file if none exists
+        csv_file = get_latest_csv_file() or current_csv_file
+
+    # Write to the appropriate CSV file
+    if os.path.exists(csv_file):
         # if file exists then just append to it
-        DataFrame([entry]).to_csv(CSV_FILE, mode="a", header=False, index=False)
+        DataFrame([entry]).to_csv(csv_file, mode="a", header=False, index=False)
     else:
         # else create file and add header
-        DataFrame([entry]).to_csv(CSV_FILE, mode="w", header=True, index=False)
+        DataFrame([entry]).to_csv(csv_file, mode="w", header=True, index=False)
+
+def get_current_csv_file() -> str:
+    """Get the current day's CSV file path based on UTC timestamp."""
+    current_time = datetime.now(timezone.utc)
+    # Get the start of the current UTC day
+    day_start = current_time.replace(hour=0, minute=0, second=0, microsecond=0)
+    timestamp = int(day_start.timestamp())
+    return os.path.join(logs_dir, CSV_FILE_PATTERN.format(timestamp=timestamp))
+
+def get_latest_csv_file() -> str | None:
+    """Get the most recent CSV file from the logs directory."""
+    csv_files = [f for f in os.listdir(logs_dir) if f.startswith("table_") and f.endswith(".csv")]
+    if not csv_files:
+        return None
+    # Sort by timestamp in filename and get the most recent
+    latest_file = sorted(csv_files, key=lambda x: int(x.split("_")[1].split(".")[0]))[-1]
+    return os.path.join(logs_dir, latest_file)


### PR DESCRIPTION
**Issue:**
When starting the LVM, with a command like `uv run layer-values-monitor /home/admin/layerd pazu2 test /home/admin/.layer  --global-percentage-alert-threshold 0.10`, error was returned that default threshold flags were required even when all flags were provided.

Fix:
Hard coded all default thresholds in main.py except for `--global-percentage-alert-threshold` which is still required.

**Issue:**
Was getting errors related to parsing config after any changes were made to config.toml.

Fix:
Changed the logic in monitor.py to not require all of the thresholds to be set for all of the metrics.

**Issue:**
The table.csv file grows so quickly that after a few days it becomes very difficult to work with.

fix:
Now each table has a timestamp, and a new table is created when MAX_TABLE_ROWS is reached. (configurable in env)