### PR TITLE
Minor fixes

### DIFF
--- a/reports/pr-33-review/01-bug-finder-report.md
+++ b/reports/pr-33-review/01-bug-finder-report.md
@@ -1,0 +1,102 @@
+# Bug Finder Report
+
+Repo: `layer-values-monitor`  
+PR: `#33` - `TRBBridgeV2 report handling.`  
+Branch: `trbbridgev2`  
+Base: `upstream/main`
+
+## Findings
+
+### BF-1
+1. **Location/identifier:** `src/layer_values_monitor/monitor.py` - `inspect_spotprice_path` (staleness block around lines 736-745, then continues with `result` around lines 747-772)
+2. **Description:** If `get_with_staleness` reports `is_stale`, the code logs and sends a staleness Discord alert but still uses the same cached `result` for `trusted_value` and dispute logic. There is no forced refresh or abort, so monitoring can treat stale oracle/API data as authoritative.
+3. **Impact level:** Critical
+4. **Points awarded:** 10
+
+### BF-2
+1. **Location/identifier:** `src/layer_values_monitor/monitor.py` - `inspect` Discord branch, interaction with `perform_dispute_verification` when immediate refresh cancels a dispute
+2. **Description:** When the first (cached) check is disputable but the immediate fresh fetch clears the dispute, `second_trusted_value` stays `None`. The UI falls through to the standard single-check path and formats the alert with `trusted_value` equal to the first/cached value only, so operators never see the fresh value (for example `99.5`) that actually justified canceling the dispute.
+3. **Impact level:** Medium
+4. **Points awarded:** 5
+
+### BF-3
+1. **Location/identifier:** `src/layer_values_monitor/monitor.py` - `inspect_aggregate_report` (`fetch_value_cached(feed, query_id, logger)`)
+2. **Description:** `query_type` is resolved from the query object but is not passed into `fetch_value_cached`, so per-query `check_interval` and staleness behavior from `ConfigWatcher` is ignored for aggregates. TTL falls back to the global `_ttl` snapshot, which can diverge from per-query settings and from single-report inspection.
+3. **Impact level:** Medium
+4. **Points awarded:** 5
+
+### BF-4
+1. **Location/identifier:** `src/layer_values_monitor/monitor.py` - `inspect_reports` deprecated handling
+2. **Description:** For a deprecated query type, the code loops per report and calls `deprecated_query_type_alert` each time. A single batch with many reports can produce many identical Discord alerts, creating noise, possible rate-limit pressure, and reduced signal.
+3. **Impact level:** Medium
+4. **Points awarded:** 5
+
+### BF-5
+1. **Location/identifier:** `src/layer_values_monitor/telliot_feeds.py` - `fetch_value_cached`
+2. **Description:** There is no request coalescing or per-query lock. Concurrent tasks that miss cache can all call `fetch_value` together, defeating rate-limit protection and duplicating work under load.
+3. **Impact level:** Medium
+4. **Points awarded:** 5
+
+### BF-6
+1. **Location/identifier:** `README.md` / `env.example` vs `src/layer_values_monitor/monitor.py` - `inspect_trbbridge_reports` (`chain_id = int(os.getenv("TRBBRIDGE_CHAIN_ID", "1"))`)
+2. **Description:** Docs and `env.example` imply Sepolia-style usage (`11155111`), but the code default if the variable is unset is `1` (mainnet). Operators who omit the env var get a chain ID that does not match documented defaults, risking wrong RPC or contract context.
+3. **Impact level:** Medium
+4. **Points awarded:** 5
+
+### BF-7
+1. **Location/identifier:** Repo root - `config.toml.example` renamed to `config_example.toml`
+2. **Description:** External scripts, CI, or docs that still reference `config.toml.example` will break or copy the wrong file after upgrade.
+3. **Impact level:** Medium
+4. **Points awarded:** 5
+
+### BF-8
+1. **Location/identifier:** `src/layer_values_monitor/dispute.py` - `is_disputable` percentage branch
+2. **Description:** Only `trusted_value is None` is guarded. If `metric` is `percentage` and `trusted_value == 0`, `(reported_value - trusted_value) / trusted_value` raises `ZeroDivisionError`. This path is unchanged in spirit and remains a runtime footgun next to the new `None` guard.
+3. **Impact level:** Medium
+4. **Points awarded:** 5
+
+### BF-9
+1. **Location/identifier:** `src/layer_values_monitor/monitor.py` + `src/layer_values_monitor/telliot_feeds.py` - config reload vs `initialize_cache_with_config` / `_ttl`
+2. **Description:** `initialize_cache_with_config` sets `_price_cache._ttl` once at startup. `ConfigWatcher.reload_config()` can change `[cache]` and intervals later, but the cache's default `_ttl` is not refreshed. Any code path that calls `fetch_value_cached` without `query_type` (for example aggregates) keeps using the old default TTL until restart.
+3. **Impact level:** Medium
+4. **Points awarded:** 5
+
+### BF-10
+1. **Location/identifier:** `pyproject.toml` - `telliot-feeds>=0.4.14` changed to `>=0.4.15`
+2. **Description:** Relaxing to a lower-bound-only constraint, while `uv.lock` pins a version, allows future `uv lock --upgrade` or non-lock installs to pull newer telliot-feeds releases without a deliberate review. Behavior of feeds and sources can change out of band.
+3. **Impact level:** Low
+4. **Points awarded:** 1
+
+### BF-11
+1. **Location/identifier:** `src/layer_values_monitor/telliot_feeds.py` - `PriceCache.get_stats`
+2. **Description:** `get_stats` reads `_hits`, `_misses`, and `len(self._cache)` without synchronizing with the async lock used elsewhere, so logged cache stats can be internally inconsistent under concurrency. This is benign but misleading operational signal.
+3. **Impact level:** Low
+4. **Points awarded:** 1
+
+### BF-12
+1. **Location/identifier:** `src/layer_values_monitor/monitor.py` `inspect_spotprice_path` + `src/layer_values_monitor/telliot_feeds.py` `PriceCache.get` / `get_with_staleness`
+2. **Description:** Each inspection typically calls `cache.get` and then `get_with_staleness`, and both methods bump hit or miss counters. Periodic logs therefore double-count logical lookups and distort hit-rate interpretation.
+3. **Impact level:** Low
+4. **Points awarded:** 1
+
+### BF-13
+1. **Location/identifier:** `src/layer_values_monitor/main.py` - `--check-interval` help text
+2. **Description:** Help still refers to `config.toml` as the source of the default while the example file is `config_example.toml` and users are told to copy it to `config.toml`, which can create confusion about which file the string refers to.
+3. **Impact level:** Low
+4. **Points awarded:** 1
+
+### BF-14
+1. **Location/identifier:** `src/layer_values_monitor/monitor.py` - `inspect_evmcall_path` vs `inspect_spotprice_path`
+2. **Description:** Staleness detection and `send_staleness_alert` are implemented for SpotPrice only. EVMCall uses the same cached fetch pattern but has no parallel staleness alerting, so operators get asymmetric visibility for similar failure modes such as stuck or old cache.
+3. **Impact level:** Low
+4. **Points awarded:** 1
+
+### BF-15
+1. **Location/identifier:** `src/layer_values_monitor/monitor.py` - `inspect_aggregate_report`
+2. **Description:** `get_query` is invoked twice back-to-back with the same `query_data`, creating redundant work and a minor clarity cost.
+3. **Impact level:** Low
+4. **Points awarded:** 1
+
+## Total Score
+
+**56**

--- a/reports/pr-33-review/02-bug-skeptic-report.md
+++ b/reports/pr-33-review/02-bug-skeptic-report.md
@@ -1,0 +1,108 @@
+# Bug Skeptic Report
+
+Repo: `layer-values-monitor`  
+PR: `#33` - `TRBBridgeV2 report handling.`  
+Branch: `trbbridgev2`  
+Base: `upstream/main`
+
+## Review
+
+### BF-1 - original score: 10
+- **Counter-argument:** Staleness uses `ConfigWatcher.get_staleness_threshold` = `get_check_interval(...) * staleness_alert_multiplier`, while cache validity in `PriceCache.get` uses the same `get_check_interval` as TTL. For any `staleness_alert_multiplier >= 1`, staleness threshold is greater than or equal to TTL, so if `cache.get` returns a hit, `get_with_staleness` cannot report `is_stale` for that same entry. The scenario only appears if an operator sets `staleness_alert_multiplier < 1`, which is not documented as supported.
+- **Confidence:** 82%
+- **Decision:** DISPROVE
+- **Points gained/risked:** +10
+
+### BF-2 - original score: 5
+- **Counter-argument:** `perform_dispute_verification` sets `immediate_refresh_value` but never maps it to `second_trusted_value`; `second_trusted_value` is only set from the final fetch after the 10-second wait. On the early return when the immediate refresh clears the dispute, `second_trusted_value` remains `None`, and the Discord branch falls back to formatting the alert with the original cached `trusted_value`.
+- **Confidence:** 92%
+- **Decision:** ACCEPT
+- **Points gained/risked:** -5 (risked if dismissed: -10)
+
+### BF-3 - original score: 5
+- **Counter-argument:** `inspect_aggregate_report` resolves `query_type` but calls `fetch_value_cached(feed, query_id, logger)` without passing it, so `_get_ttl_for_query` falls back to `self._ttl` instead of per-query `ConfigWatcher.get_check_interval`.
+- **Confidence:** 95%
+- **Decision:** ACCEPT
+- **Points gained/risked:** -5
+
+### BF-4 - original score: 5
+- **Counter-argument:** The deprecated path explicitly loops `for report in reports` and calls `deprecated_query_type_alert` per report.
+- **Confidence:** 95%
+- **Decision:** ACCEPT
+- **Points gained/risked:** -5
+
+### BF-5 - original score: 5
+- **Counter-argument:** `fetch_value_cached` only uses `cache.get`, then on miss awaits `fetch_value` with no per-`query_id` mutex or single-flight logic. Concurrent coroutines can all miss and call `fetch_value` together.
+- **Confidence:** 88%
+- **Decision:** ACCEPT
+- **Points gained/risked:** -5
+
+### BF-6 - original score: 5
+- **Counter-argument:** Code uses `int(os.getenv("TRBBRIDGE_CHAIN_ID", "1"))`. `README.md` and `env.example` both show `11155111`. The default in code is therefore inconsistent with the documented setup.
+- **Confidence:** 95%
+- **Decision:** ACCEPT
+- **Points gained/risked:** -5
+
+### BF-7 - original score: 5
+- **Counter-argument:** The repo contains `config_example.toml` and no in-repo references to `config.toml.example` were found. This looks like a possible external migration issue, not a demonstrated breakage inside this repository.
+- **Confidence:** 80%
+- **Decision:** DISPROVE
+- **Points gained/risked:** +5
+
+### BF-8 - original score: 5
+- **Counter-argument:** `is_disputable` guards `trusted_value is None` only. For `metric == "percentage"` it computes `(reported_value - trusted_value) / trusted_value`, which divides by zero if `trusted_value == 0`.
+- **Confidence:** 93%
+- **Decision:** ACCEPT
+- **Points gained/risked:** -5
+
+### BF-9 - original score: 5
+- **Counter-argument:** `initialize_cache_with_config` sets `_price_cache._ttl` once from `config_watcher.get_check_interval()`. `reload_config` updates `cache_settings` on the watcher, but nothing updates `_price_cache._ttl` afterward. For calls without `query_type`, TTL falls back to that stale `_ttl`, which matches aggregate behavior in BF-3.
+- **Confidence:** 90%
+- **Decision:** ACCEPT
+- **Points gained/risked:** -5
+
+### BF-10 - original score: 1
+- **Counter-argument:** This is dependency-policy or supply-chain risk, not a defect in application logic. `uv.lock` pins the resolved version for locked installs.
+- **Confidence:** 85%
+- **Decision:** DISPROVE
+- **Points gained/risked:** +1
+
+### BF-11 - original score: 1
+- **Counter-argument:** `get_stats` reads `_hits`, `_misses`, and `len(self._cache)` without `async with self._lock`, unlike the mutating paths.
+- **Confidence:** 90%
+- **Decision:** ACCEPT
+- **Points gained/risked:** -1
+
+### BF-12 - original score: 1
+- **Counter-argument:** `inspect_spotprice_path` calls `fetch_value_cached` (which calls `cache.get` and counts a hit on success) and then `get_with_staleness` (which increments `_hits` again for the same existing entry).
+- **Confidence:** 92%
+- **Decision:** ACCEPT
+- **Points gained/risked:** -1
+
+### BF-13 - original score: 1
+- **Counter-argument:** `main.py` help still says the default is from `config.toml` while the checked-in template is `config_example.toml`; the wording is easy to misread.
+- **Confidence:** 78%
+- **Decision:** ACCEPT
+- **Points gained/risked:** -1
+
+### BF-14 - original score: 1
+- **Counter-argument:** `inspect_spotprice_path` runs staleness alerting, while `inspect_evmcall_path` fetches via cache but has no analogous `get_with_staleness` or `send_staleness_alert` block. This is an observability asymmetry rather than an incorrect comparison claim.
+- **Confidence:** 88%
+- **Decision:** ACCEPT
+- **Points gained/risked:** -1
+
+### BF-15 - original score: 1
+- **Counter-argument:** `get_query(query_data)` is called twice in `inspect_aggregate_report` with the same `query_data`.
+- **Confidence:** 98%
+- **Decision:** ACCEPT
+- **Points gained/risked:** -1
+
+## Summary
+
+- **Total bugs disproved:** 3 (`BF-1`, `BF-7`, `BF-10`)
+- **Total bugs accepted as real:** 12
+- **Final score:** `-29`
+
+## Verified Bug List
+
+`BF-2`, `BF-3`, `BF-4`, `BF-5`, `BF-6`, `BF-8`, `BF-9`, `BF-11`, `BF-12`, `BF-13`, `BF-14`, `BF-15`

--- a/reports/pr-33-review/03-final-arbiter-report.md
+++ b/reports/pr-33-review/03-final-arbiter-report.md
@@ -1,0 +1,149 @@
+# Final Arbiter Report
+
+Repo: `layer-values-monitor`  
+PR: `#33` - `TRBBridgeV2 report handling.`  
+Branch: `trbbridgev2`  
+Base: `upstream/main`
+
+## Final Judgments
+
+### BF-1
+
+- **Bug Finder's claim (summary):** Stale-cache alerting can fire while the same cached value is still used as the trusted value for dispute logic.
+- **Skeptic's counter (summary):** With `staleness_alert_multiplier >= 1`, a value that is still a TTL-valid cache hit cannot also exceed the staleness threshold; this is unreachable under default and example configs.
+- **Your analysis:** `fetch_value_cached` only returns a cached row when `age < get_check_interval(...)`. Staleness uses `age > get_check_interval(...) * staleness_alert_multiplier`. The same `get_check_interval` base is used for both. If `staleness_alert_multiplier >= 1`, then staleness threshold is greater than or equal to TTL, so no age can satisfy both "valid hit" and "stale." The overlap would require `staleness_alert_multiplier < 1`, which is allowed by TOML but not documented or intended. Under the default value `3` and the example config, the Finder scenario does not occur.
+- **VERDICT:** NOT A BUG
+- **Confidence:** High
+
+### BF-2
+
+- **Bug Finder's claim (summary):** If an immediate refresh clears a dispute, the Discord alert still reflects only the first cached trusted value, not the fresh value that cleared the dispute.
+- **Skeptic's counter (summary):** Accept - `immediate_refresh_value` is not surfaced in the message when the refresh clears the dispute.
+- **Your analysis:** `perform_dispute_verification` sets `immediate_refresh_value` when the fresh fetch succeeds but returns early when `not immediate_disputable` without populating `second_trusted_value`. In `inspect`, the rich double-check message is only used when `second_trusted_value is not None`; otherwise the standard branch uses `trusted_value`, which is the original cached value passed into `inspect`. Operators therefore never see the refresh that canceled the dispute.
+- **VERDICT:** REAL BUG
+- **Confidence:** High
+
+### BF-3
+
+- **Bug Finder's claim (summary):** `inspect_aggregate_report` resolves `query_type` but does not pass it into `fetch_value_cached`, so per-query TTL and staleness from config are ignored on that path.
+- **Skeptic's counter (summary):** Accept.
+- **Your analysis:** `query_type` is set from `query.__class__.__name__`, but `fetch_value_cached(feed, query_id, logger)` is called without `query_type=...`, so `_get_ttl_for_query` falls back to `self._ttl` instead of per-query intervals.
+- **VERDICT:** REAL BUG
+- **Confidence:** High
+
+### BF-4
+
+- **Bug Finder's claim (summary):** Deprecated-query handling sends one Discord alert per report in the batch, causing alert spam.
+- **Skeptic's counter (summary):** Accept.
+- **Your analysis:** `for report in reports: deprecated_query_type_alert(...)` loops every report for the same deprecated-type batch.
+- **VERDICT:** REAL BUG
+- **Confidence:** High
+
+### BF-5
+
+- **Bug Finder's claim (summary):** No per-key coalescing on cache miss, so concurrent misses can stampede the upstream API.
+- **Skeptic's counter (summary):** Accept.
+- **Your analysis:** `fetch_value_cached` uses `get` and then, on miss, awaits `fetch_value` with no in-flight deduplication lock or future sharing.
+- **VERDICT:** REAL BUG
+- **Confidence:** High
+
+### BF-6
+
+- **Bug Finder's claim (summary):** `TRBBRIDGE_CHAIN_ID` defaults to `1` in code while docs and example env use `11155111`.
+- **Skeptic's counter (summary):** Accept.
+- **Your analysis:** `monitor.py` uses `int(os.getenv("TRBBRIDGE_CHAIN_ID", "1"))`; `env.example` and `README.md` document `11155111`. If the env var is omitted, behavior diverges from documented expectations.
+- **VERDICT:** REAL BUG
+- **Confidence:** High
+
+### BF-7
+
+- **Bug Finder's claim (summary):** Renaming `config.toml.example` to `config_example.toml` breaks external scripts or docs.
+- **Skeptic's counter (summary):** Disprove - no in-repo references to the old filename were found; breakage is only hypothetical outside the repo.
+- **Your analysis:** No in-repo references to `config.toml.example` were found. Runtime still expects `config.toml`, which users create locally. Any external breakage would be outside this repository and is not a logic defect in the application itself.
+- **VERDICT:** NOT A BUG
+- **Confidence:** Medium
+
+### BF-8
+
+- **Bug Finder's claim (summary):** Percentage metric in `is_disputable` can divide by zero when `trusted_value == 0`.
+- **Skeptic's counter (summary):** Accept.
+- **Your analysis:** `percent_diff = (reported_value - trusted_value) / trusted_value` has no guard when `trusted_value` is numeric zero.
+- **VERDICT:** REAL BUG
+- **Confidence:** High
+
+### BF-9
+
+- **Bug Finder's claim (summary):** Config reload updates watcher cache settings, but `PriceCache._ttl` is only set at init, so code paths without `query_type` keep the old global TTL until restart.
+- **Skeptic's counter (summary):** Accept.
+- **Your analysis:** `initialize_cache_with_config` sets `_price_cache._ttl` once; `watch_config` only calls `reload_config()` and does not refresh `_price_cache._ttl`. Paths that pass `query_type` use `ConfigWatcher.get_check_interval` live; paths that omit `query_type` use stale `_ttl`.
+- **VERDICT:** REAL BUG
+- **Confidence:** High
+
+### BF-10
+
+- **Bug Finder's claim (summary):** Relaxing `telliot-feeds` to `>=0.4.15` is a bug because future installs may change behavior.
+- **Skeptic's counter (summary):** Disprove - this is versioning risk, not a concrete application defect.
+- **Your analysis:** This is dependency policy and reproducibility concern, not incorrect program logic at a point in time. It may be worth tracking as release hygiene, but not as an application bug.
+- **VERDICT:** NOT A BUG
+- **Confidence:** High
+
+### BF-11
+
+- **Bug Finder's claim (summary):** `PriceCache.get_stats` reads mutable counters and cache size without the async lock, so stats can be internally inconsistent.
+- **Skeptic's counter (summary):** Accept.
+- **Your analysis:** `get_stats` is synchronous and does not use `self._lock` while other coroutines mutate `_hits`, `_misses`, and `_cache` under the lock.
+- **VERDICT:** REAL BUG
+- **Confidence:** High
+
+### BF-12
+
+- **Bug Finder's claim (summary):** SpotPrice inspection double-counts cache stats by calling both `get` and `get_with_staleness`.
+- **Skeptic's counter (summary):** Accept.
+- **Your analysis:** A hit path runs `cache.get`, which increments hits, and then `get_with_staleness`, which increments hits again for the same entry.
+- **VERDICT:** REAL BUG
+- **Confidence:** High
+
+### BF-13
+
+- **Bug Finder's claim (summary):** `--check-interval` help text is confusing because it cites `config.toml` while the committed example is `config_example.toml`.
+- **Skeptic's counter (summary):** Accept - mildly confusing.
+- **Your analysis:** The help string says "default: 180s from `config.toml`"; the example file is named `config_example.toml` with instructions to copy it to `config.toml`. Runtime path is `config.toml`, so the text is not wrong, but the naming mismatch can still confuse readers.
+- **VERDICT:** REAL BUG
+- **Confidence:** Medium
+
+### BF-14
+
+- **Bug Finder's claim (summary):** SpotPrice has staleness alerts but EVMCall does not, creating asymmetric stale-cache visibility.
+- **Skeptic's counter (summary):** Accept.
+- **Your analysis:** `inspect_spotprice_path` calls `get_with_staleness` and `send_staleness_alert`; `inspect_evmcall_path` only uses `fetch_value_cached` with no staleness check or alert.
+- **VERDICT:** REAL BUG
+- **Confidence:** High
+
+### BF-15
+
+- **Bug Finder's claim (summary):** `inspect_aggregate_report` calls `get_query` twice redundantly.
+- **Skeptic's counter (summary):** Accept.
+- **Your analysis:** `inspect_aggregate_report` calls `get_query(query_data)` twice with the same `query_data` after an unnecessary second `None` check.
+- **VERDICT:** REAL BUG
+- **Confidence:** High
+
+## Final Summary
+
+- **Total bugs confirmed as real:** 12
+- **Total bugs dismissed:** 3 (`BF-1`, `BF-7`, `BF-10`)
+
+## Confirmed Bugs With Severity
+
+- `BF-2`: Medium - misleading Discord context when refresh cancels dispute
+- `BF-3`: Medium - wrong cache TTL behavior for aggregate inspection
+- `BF-4`: Low-Medium - duplicate alert noise
+- `BF-5`: Medium - thundering herd on upstream under concurrency
+- `BF-6`: Medium - wrong default chain if env is unset
+- `BF-8`: High - unhandled `ZeroDivisionError` on percentage metric
+- `BF-9`: Low-Medium - stale global TTL after reload for paths without `query_type`
+- `BF-11`: Low - stats can be inconsistent
+- `BF-12`: Low - inflated cache hit and miss metrics
+- `BF-13`: Low - CLI help text confusion
+- `BF-14`: Low - observability gap for EVMCall stale cache
+- `BF-15`: Low - redundant work and clarity issue
+

--- a/src/layer_values_monitor/dispute.py
+++ b/src/layer_values_monitor/dispute.py
@@ -204,8 +204,10 @@ def is_disputable(
         return None, None, None
 
     if metric.lower() == "percentage":
-        percent_diff: float = (reported_value - trusted_value) / trusted_value
-        percent_diff = abs(percent_diff)
+        if trusted_value == 0:
+            logger.error("Cannot determine if disputable: trusted_value is 0 for percentage metric")
+            return None, None, None
+        percent_diff = abs((reported_value - trusted_value) / trusted_value)
         logger.debug(f"percent diff: {percent_diff}, reported value: {reported_value} - trusted value: {trusted_value}")
 
         # Handle None values for thresholds - but don't override valid thresholds

--- a/src/layer_values_monitor/monitor.py
+++ b/src/layer_values_monitor/monitor.py
@@ -975,7 +975,9 @@ async def inspect_aggregate_report(
         logger.error(f"Unable to get feed for aggregate report query id: {query_id}")
         return None
 
-    result = await fetch_value_cached(feed, query_id, logger)
+    # Pass the resolved query type so aggregate checks use the same TTL rules
+    # as single-report inspection for that query.
+    result = await fetch_value_cached(feed, query_id, logger, query_type=query_type)
     if result is None:
         logger.error(f"Unable to fetch trusted value for aggregate report query id: {query_id}")
         return None

--- a/src/layer_values_monitor/monitor.py
+++ b/src/layer_values_monitor/monitor.py
@@ -6,7 +6,8 @@ import logging
 import os
 import random
 import time
-from typing import Any, Awaitable, Callable
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from layer_values_monitor.catchup import HeightTracker, get_current_height, process_missed_blocks
 from layer_values_monitor.config_watcher import ConfigWatcher

--- a/src/layer_values_monitor/monitor.py
+++ b/src/layer_values_monitor/monitor.py
@@ -1618,6 +1618,12 @@ async def perform_dispute_verification(
             result["immediate_diff"] = immediate_diff
 
             if not immediate_disputable:
+                # Reuse the existing "second check" alert fields so operators can see
+                # the refreshed trusted value that cleared the dispute.
+                result["second_trusted_value"] = result["immediate_refresh_value"]
+                result["second_trusted_time"] = result["immediate_refresh_time"]
+                result["second_check_disputable"] = immediate_disputable
+                result["second_diff"] = immediate_diff
                 logger.info(
                     f"⚠️ Fresh check did NOT cross threshold (diff: {immediate_diff})."
                     " Dispute cancelled - likely stale cache."

--- a/src/layer_values_monitor/monitor.py
+++ b/src/layer_values_monitor/monitor.py
@@ -906,7 +906,7 @@ async def new_reports_queue_handler(
         # Periodic cache statistics logging
         reports_processed += len(new_reports)
         if reports_processed >= cache_log_interval:
-            cache_stats = get_price_cache().get_stats()
+            cache_stats = await get_price_cache().get_stats()
             logger.info(
                 f"💾 Price cache stats: {cache_stats['hits']} hits, {cache_stats['misses']} misses, "
                 f"{cache_stats['hit_rate']} hit rate, {cache_stats['size']} entries cached"

--- a/src/layer_values_monitor/monitor.py
+++ b/src/layer_values_monitor/monitor.py
@@ -6,7 +6,7 @@ import logging
 import os
 import random
 import time
-from typing import Any
+from typing import Any, Awaitable, Callable
 
 from layer_values_monitor.catchup import HeightTracker, get_current_height, process_missed_blocks
 from layer_values_monitor.config_watcher import ConfigWatcher
@@ -31,6 +31,7 @@ from layer_values_monitor.logger import console_logger
 from layer_values_monitor.saga_contract import SagaContractManager
 from layer_values_monitor.telliot_feeds import (
     CacheResult,
+    extract_query_info,
     fetch_value_cached,
     get_feed,
     get_price_cache,
@@ -983,6 +984,11 @@ async def inspect_aggregate_report(
         return None
     trusted_value, _ = result
 
+    if metrics.metric.lower() == "percentage" and trusted_value == 0:
+        query_info = extract_query_info(query, query_type=query_type)
+        await send_zero_trusted_value_alert(query_id, query_type, query_info, logger)
+        return None
+
     # Decode the aggregate hex value
     try:
         reported_value = decode_hex_value(agg_report.value)
@@ -1418,6 +1424,35 @@ async def send_staleness_alert(
         logger.error(f"Failed to send staleness alert: {e}")
 
 
+async def send_zero_trusted_value_alert(
+    query_id: str,
+    query_type: str,
+    query_info: str,
+    logger: logging.Logger,
+    reported_value: Any | None = None,
+) -> None:
+    """Send Discord alert when a percentage-based trusted value is zero.
+
+    A zero trusted value makes percentage comparisons invalid, so we alert and
+    skip inspection instead of treating the report as disputable.
+    """
+    try:
+        query_label = query_info if isinstance(query_info, str) and query_info else query_type
+
+        alert_msg = f"**QueryId:** {query_id}\n"
+        alert_msg += f"**QueryType:** {query_type}\n"
+        if query_label and query_label not in {query_type, "Unknown"}:
+            alert_msg += f"**Asset:** {query_label}\n"
+        if reported_value is not None:
+            alert_msg += f"**Reported Value:** {reported_value}\n"
+        alert_msg += f"**Status:** Trusted value for {query_label} query was 0"
+
+        logger.warning(f"Zero trusted value alert:\n{alert_msg}")
+        generic_alert(alert_msg, description="⚠️ **TRUSTED VALUE WAS 0**")
+    except Exception as e:
+        logger.error(f"Failed to send zero trusted value alert: {e}")
+
+
 async def send_unsupported_query_alert(
     query_id: str,
     query_type: str,
@@ -1554,6 +1589,7 @@ async def perform_dispute_verification(
     metrics: Metrics,
     logger: logging.Logger,
     trusted_value_fetcher: Any = None,
+    zero_trusted_value_handler: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Perform verification logic to determine if a dispute should be submitted.
 
@@ -1588,6 +1624,7 @@ async def perform_dispute_verification(
         "second_trusted_time": None,
         "second_check_disputable": None,
         "second_diff": None,
+        "zero_trusted_value_detected": False,
     }
 
     if disputable and trusted_value_fetcher is not None:
@@ -1606,6 +1643,13 @@ async def perform_dispute_verification(
             )
             result["immediate_refresh_time"] = time.time()
             logger.info(f"✅ Fresh trusted value fetched: {result['immediate_refresh_value']}")
+
+            if metrics.metric.lower() == "percentage" and result["immediate_refresh_value"] == 0:
+                result["zero_trusted_value_detected"] = True
+                if zero_trusted_value_handler is not None:
+                    await zero_trusted_value_handler()
+                logger.warning("Fresh trusted value was 0. Cancelling dispute.")
+                return result
 
             # Step 2: Check if fresh value still crosses threshold
             _, immediate_disputable, immediate_diff = is_disputable(
@@ -1654,6 +1698,13 @@ async def perform_dispute_verification(
             result["second_trusted_value"] = result["final_trusted_value"]
             result["second_trusted_time"] = result["final_trusted_time"]
             logger.info(f"✅ Final trusted value fetched: {result['final_trusted_value']}")
+
+            if metrics.metric.lower() == "percentage" and result["final_trusted_value"] == 0:
+                result["zero_trusted_value_detected"] = True
+                if zero_trusted_value_handler is not None:
+                    await zero_trusted_value_handler()
+                logger.warning("Final trusted value was 0. Cancelling dispute.")
+                return result
 
             # Step 4: Final check - only dispute if still crosses threshold
             _, final_disputable, final_diff = is_disputable(
@@ -1779,6 +1830,22 @@ async def inspect(
     # Store first trusted value timestamp
     first_trusted_value = trusted_value
     first_trusted_time = time.time()
+    query_info = extract_query_info(query, query_type=report.query_type)
+
+    async def alert_zero_trusted_value() -> None:
+        await send_zero_trusted_value_alert(
+            report.query_id,
+            report.query_type,
+            query_info,
+            logger,
+            reported_value=reported_value,
+        )
+
+    if metrics.metric.lower() == "percentage" and trusted_value == 0:
+        await alert_zero_trusted_value()
+        display["DISPUTABLE"] = False
+        add_to_table(display)
+        return None
 
     # compare values and check against threshold- three metrics(percentage, equality, range)
     alertable, disputable, diff = is_disputable(
@@ -1818,7 +1885,13 @@ async def inspect(
 
     # Perform dispute verification (double-check for SpotPrice, single-check for others)
     verification_result = await perform_dispute_verification(
-        disputable, diff, reported_value, metrics, logger, trusted_value_fetcher
+        disputable,
+        diff,
+        reported_value,
+        metrics,
+        logger,
+        trusted_value_fetcher,
+        zero_trusted_value_handler=alert_zero_trusted_value,
     )
 
     should_dispute = verification_result["should_dispute"]
@@ -1827,6 +1900,12 @@ async def inspect(
     second_trusted_time = verification_result["second_trusted_time"]
     second_check_disputable = verification_result["second_check_disputable"]
     second_diff = verification_result["second_diff"]
+    zero_trusted_value_detected = verification_result["zero_trusted_value_detected"]
+
+    if zero_trusted_value_detected:
+        display["DISPUTABLE"] = False
+        add_to_table(display)
+        return None
 
     # Send Discord alert AFTER double-check completes (or immediately if no double-check)
     if alertable or (disputable and trusted_value_fetcher is not None):
@@ -1835,9 +1914,7 @@ async def inspect(
 
         from layer_values_monitor.discord import build_alert_message, format_difference, format_values
         from layer_values_monitor.dispute import get_disputer_address, validate_keyring_config
-        from layer_values_monitor.telliot_feeds import extract_query_info
 
-        query_info = extract_query_info(query, query_type=report.query_type)
         diff_str = format_difference(diff, metrics.metric)
 
         # Build message based on whether we did double-check

--- a/src/layer_values_monitor/monitor.py
+++ b/src/layer_values_monitor/monitor.py
@@ -966,11 +966,6 @@ async def inspect_aggregate_report(
     # Get feed and trusted value (same logic as inspect_reports)
     # Uses cached fetch - aggregate reports often arrive shortly after new reports
     # for the same query_id, so we can reuse the cached value
-    query = get_query(query_data)
-    if query is None:
-        logger.error(f"Unable to parse query data for aggregate report query id: {query_id}")
-        return None
-
     feed = await get_feed(query_id, query, logger)
     if feed is None:
         logger.error(f"Unable to get feed for aggregate report query id: {query_id}")

--- a/src/layer_values_monitor/monitor.py
+++ b/src/layer_values_monitor/monitor.py
@@ -729,11 +729,6 @@ async def inspect_spotprice_path(
         logger.error("Unable to get feed")
         return None
 
-    # Use cached fetch to reduce API calls (e.g., CoinGecko)
-    # Multiple reports for the same query_id will share the cached value
-    logger.debug("Fetching trusted value from feed (with cache)...")
-    result = await fetch_value_cached(feed, query_id, logger, query_type=query_type)
-
     # Check for staleness
     cache = get_price_cache()
     cache_result = await cache.get_with_staleness(query_id, query_type)
@@ -744,6 +739,11 @@ async def inspect_spotprice_path(
         )
         # Send staleness alert
         await send_staleness_alert(query_id, query_type, asset_pair, cache_result, logger)
+
+    # Use cached fetch to reduce API calls (e.g., CoinGecko)
+    # Multiple reports for the same query_id will share the cached value
+    logger.debug("Fetching trusted value from feed (with cache)...")
+    result = await fetch_value_cached(feed, query_id, logger, query_type=query_type)
 
     if result is None:
         logger.error("Unable to fetch trusted value")
@@ -820,8 +820,19 @@ async def inspect_evmcall_path(
 
     # Create fetcher lambda for immediate refresh when threshold is breached
     # Note: Uses force_refresh=True to bypass cache
-    async def fetch_trusted_value() -> tuple[Any, Any]:
-        return await fetch_value_cached(feed, query_id, logger, force_refresh=True, query_type=query_type)
+    async def fetch_trusted_value() -> tuple[Any, Any] | None:
+        refreshed = await fetch_value_cached(feed, query_id, logger, force_refresh=True, query_type=query_type)
+        if refreshed is None:
+            return None
+
+        refreshed_value_tuple, refreshed_timestamp = refreshed
+        if not isinstance(refreshed_value_tuple, tuple) or len(refreshed_value_tuple) != 2:
+            logger.error(
+                f"Expected tuple (value, timestamp) from refreshed EVMCall feed, got: {type(refreshed_value_tuple)}"
+            )
+            return None
+
+        return refreshed_value_tuple[0], refreshed_timestamp
 
     logger.debug(f"Inspecting {len(reports)} EVMCall report(s)...")
     for r in reports:
@@ -904,7 +915,7 @@ async def new_reports_queue_handler(
             logger.warning(f"🧹 Cleaned up {len(completed_tasks)} completed tasks (active: {len(running_tasks)})")
 
         # Periodic cache statistics logging
-        reports_processed += len(new_reports)
+        reports_processed += sum(len(reports) for reports in new_reports.values())
         if reports_processed >= cache_log_interval:
             cache_stats = await get_price_cache().get_stats()
             logger.info(
@@ -1620,6 +1631,8 @@ async def perform_dispute_verification(
         "second_check_disputable": None,
         "second_diff": None,
         "zero_trusted_value_detected": False,
+        "verification_failed": False,
+        "verification_failure_reason": None,
     }
 
     if disputable and trusted_value_fetcher is not None:
@@ -1630,6 +1643,8 @@ async def perform_dispute_verification(
             immediate_result = await trusted_value_fetcher()
             if immediate_result is None:
                 logger.error("❌ Failed to fetch fresh trusted value. Cancelling dispute.")
+                result["verification_failed"] = True
+                result["verification_failure_reason"] = "Fresh trusted value verification failed on immediate refresh."
                 return result
 
             # Extract value from result tuple
@@ -1684,6 +1699,8 @@ async def perform_dispute_verification(
 
             if final_result is None:
                 logger.error("❌ Failed to fetch final trusted value. Cancelling dispute.")
+                result["verification_failed"] = True
+                result["verification_failure_reason"] = "Fresh trusted value verification failed during final check."
                 return result
 
             # Extract value from result tuple
@@ -1744,6 +1761,8 @@ async def perform_dispute_verification(
 
         except Exception as e:
             logger.error(f"❌ Error during dispute verification: {e}. Cancelling dispute.")
+            result["verification_failed"] = True
+            result["verification_failure_reason"] = f"Fresh trusted value verification failed: {e}"
 
     elif disputable and trusted_value_fetcher is None:
         # Single-check logic for TRBBridge queries (no fetcher available)
@@ -1896,6 +1915,8 @@ async def inspect(
     second_check_disputable = verification_result["second_check_disputable"]
     second_diff = verification_result["second_diff"]
     zero_trusted_value_detected = verification_result["zero_trusted_value_detected"]
+    verification_failed = verification_result["verification_failed"]
+    verification_failure_reason = verification_result["verification_failure_reason"]
 
     if zero_trusted_value_detected:
         display["DISPUTABLE"] = False
@@ -1966,7 +1987,7 @@ async def inspect(
 
             # Get disputer information based on dispute level and keyring config
             disputer_info = None
-            if is_disputable_flag and dispute_level != "warning":
+            if is_disputable_flag and dispute_level != "warning" and not verification_failed:
                 # Only show disputer info for disputable alerts (not warnings)
                 binary_path = os.getenv("LAYER_BINARY_PATH")
                 key_name = os.getenv("LAYER_KEY_NAME")
@@ -1995,7 +2016,11 @@ async def inspect(
             )
 
             # Determine description based on whether it's disputable
-            if alertable and not is_disputable_flag:
+            if verification_failed:
+                description = "⚠️ **VERIFICATION FAILED - NO DISPUTE SENT**"
+                reason = verification_failure_reason or "Fresh trusted value verification failed."
+                msg += f"\n**Status:** {reason}"
+            elif alertable and not is_disputable_flag:
                 description = "⚠️ **ALERT THRESHOLD TRIGGERED, BUT NOT AT DISPUTE LEVEL**"
             else:
                 description = "❗**FOUND SOMETHING**❗"

--- a/src/layer_values_monitor/telliot_feeds.py
+++ b/src/layer_values_monitor/telliot_feeds.py
@@ -162,6 +162,7 @@ class PriceCache:
 
         This method returns the cached value even if it's expired (for comparison),
         along with information about whether it's stale (too old to be trusted).
+        It is a diagnostic read, so it does not affect hit/miss statistics.
 
         Args:
             query_id: The query ID to look up
@@ -176,10 +177,8 @@ class PriceCache:
         async with self._lock:
             entry = self._cache.get(query_id)
             if entry is None:
-                self._misses += 1
                 return None
 
-            self._hits += 1
             age = time.time() - entry.fetch_time
             is_stale = age > staleness_threshold
 

--- a/src/layer_values_monitor/telliot_feeds.py
+++ b/src/layer_values_monitor/telliot_feeds.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any
 
 from clamfig.base import Registry
 from eth_abi import decode

--- a/src/layer_values_monitor/telliot_feeds.py
+++ b/src/layer_values_monitor/telliot_feeds.py
@@ -79,6 +79,7 @@ class PriceCache:
         self._lock = asyncio.Lock()
         self._in_flight: dict[str, asyncio.Task[OptionalDataPoint]] = {}
         self._config_watcher: ConfigWatcher | None = None
+        self._ttl_override: float | None = None
 
     def set_config_watcher(self, config_watcher: ConfigWatcher) -> None:
         """Set the config watcher for per-query TTL lookups.
@@ -100,8 +101,11 @@ class PriceCache:
             TTL in seconds (per-query override or global default)
 
         """
-        if self._config_watcher and query_type:
-            return self._config_watcher.get_check_interval(query_id, query_type)
+        if self._config_watcher:
+            if query_type:
+                return self._config_watcher.get_check_interval(query_id, query_type)
+            if self._ttl_override is None:
+                return self._config_watcher.get_check_interval()
         return self._ttl
 
     def _get_staleness_threshold(self, query_id: str, query_type: str | None = None) -> float:
@@ -115,8 +119,11 @@ class PriceCache:
             Staleness threshold in seconds
 
         """
-        if self._config_watcher and query_type:
-            return self._config_watcher.get_staleness_threshold(query_id, query_type)
+        if self._config_watcher:
+            if query_type:
+                return self._config_watcher.get_staleness_threshold(query_id, query_type)
+            if self._ttl_override is None:
+                return self._config_watcher.get_staleness_threshold()
         # Default: 3x the TTL
         return self._ttl * 3
 
@@ -312,6 +319,7 @@ def set_cache_ttl(ttl_seconds: float) -> None:
     """
     global _price_cache
     _price_cache._ttl = ttl_seconds
+    _price_cache._ttl_override = ttl_seconds
 
 
 def initialize_cache_with_config(config_watcher: ConfigWatcher) -> None:
@@ -323,7 +331,8 @@ def initialize_cache_with_config(config_watcher: ConfigWatcher) -> None:
     """
     global _price_cache
     _price_cache.set_config_watcher(config_watcher)
-    _price_cache._ttl = config_watcher.get_check_interval()
+    if _price_cache._ttl_override is None:
+        _price_cache._ttl = config_watcher.get_check_interval()
     logger.info(f"Price cache initialized with TTL: {_price_cache._ttl}s")
 
 

--- a/src/layer_values_monitor/telliot_feeds.py
+++ b/src/layer_values_monitor/telliot_feeds.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from clamfig.base import Registry
 from eth_abi import decode
@@ -77,6 +77,7 @@ class PriceCache:
         self._hits = 0
         self._misses = 0
         self._lock = asyncio.Lock()
+        self._in_flight: dict[str, asyncio.Task[OptionalDataPoint]] = {}
         self._config_watcher: ConfigWatcher | None = None
 
     def set_config_watcher(self, config_watcher: ConfigWatcher) -> None:
@@ -235,6 +236,42 @@ class PriceCache:
             self._cache.clear()
             self._hits = 0
             self._misses = 0
+
+    async def get_cached_or_in_flight(
+        self,
+        query_id: str,
+        query_type: str | None,
+        fetcher: Callable[[], Awaitable[OptionalDataPoint]],
+        *,
+        allow_cached: bool,
+    ) -> tuple[tuple[Any, float] | None, asyncio.Task[OptionalDataPoint] | None, bool]:
+        """Return a cached value or a shared in-flight fetch task.
+
+        This prevents a thundering herd when many callers miss the cache for the
+        same query at the same time.
+        """
+        ttl = self._get_ttl_for_query(query_id, query_type)
+
+        async with self._lock:
+            if allow_cached:
+                entry = self._cache.get(query_id)
+                if entry and self._is_valid(entry, ttl):
+                    return (entry.value, entry.timestamp), None, False
+                if entry:
+                    del self._cache[query_id]
+
+            task = self._in_flight.get(query_id)
+            if task is None:
+                task = asyncio.create_task(fetcher())
+                self._in_flight[query_id] = task
+                return None, task, True
+            return None, task, False
+
+    async def clear_in_flight(self, query_id: str, task: asyncio.Task[OptionalDataPoint]) -> None:
+        """Remove a completed in-flight fetch task if it still matches the key."""
+        async with self._lock:
+            if self._in_flight.get(query_id) is task:
+                del self._in_flight[query_id]
 
     def get_stats(self) -> dict[str, Any]:
         """Get cache statistics.
@@ -425,18 +462,36 @@ async def fetch_value_cached(
             log.debug(f"💾 Cache HIT for {query_id[:16]}... (value: {cached[0]})")
             return cached
 
-    # Cache miss or force refresh - fetch from API
-    log.debug(f"🌐 Cache MISS for {query_id[:16]}... - fetching from API")
-    result = await fetch_value(feed)
+    async def fetch_and_cache() -> OptionalDataPoint:
+        log.debug(f"🌐 Cache MISS for {query_id[:16]}... - fetching from API")
+        result = await fetch_value(feed)
 
-    if result is not None:
-        value, timestamp = result
-        # Store in cache
-        await cache.set(query_id, value, timestamp)
-        ttl = cache._get_ttl_for_query(query_id, query_type)
-        log.debug(f"💾 Cached value for {query_id[:16]}... (TTL: {ttl}s)")
+        if result is not None:
+            value, timestamp = result
+            await cache.set(query_id, value, timestamp)
+            ttl = cache._get_ttl_for_query(query_id, query_type)
+            log.debug(f"💾 Cached value for {query_id[:16]}... (TTL: {ttl}s)")
 
-    return result
+        return result
+
+    cached_after_wait, in_flight_task, is_owner = await cache.get_cached_or_in_flight(
+        query_id,
+        query_type,
+        fetch_and_cache,
+        allow_cached=not force_refresh,
+    )
+    if cached_after_wait is not None:
+        log.debug(f"💾 Cache FILLED for {query_id[:16]}... while waiting for shared fetch")
+        return cached_after_wait
+
+    if in_flight_task is None:
+        return None
+
+    try:
+        return await asyncio.shield(in_flight_task)
+    finally:
+        if is_owner:
+            await cache.clear_in_flight(query_id, in_flight_task)
 
 
 def extract_query_info(query: AbiQuery | JsonQuery | None, query_type: str | None = None) -> str:

--- a/src/layer_values_monitor/telliot_feeds.py
+++ b/src/layer_values_monitor/telliot_feeds.py
@@ -280,21 +280,27 @@ class PriceCache:
             if self._in_flight.get(query_id) is task:
                 del self._in_flight[query_id]
 
-    def get_stats(self) -> dict[str, Any]:
-        """Get cache statistics.
+    async def get_stats(self) -> dict[str, Any]:
+        """Get cache statistics from a locked snapshot.
 
         Returns:
             Dict with hits, misses, hit_rate, and size
 
         """
-        total = self._hits + self._misses
-        hit_rate = (self._hits / total * 100) if total > 0 else 0.0
+        async with self._lock:
+            hits = self._hits
+            misses = self._misses
+            size = len(self._cache)
+            ttl = self._ttl
+
+        total = hits + misses
+        hit_rate = (hits / total * 100) if total > 0 else 0.0
         return {
-            "hits": self._hits,
-            "misses": self._misses,
+            "hits": hits,
+            "misses": misses,
             "hit_rate": f"{hit_rate:.1f}%",
-            "size": len(self._cache),
-            "ttl_seconds": self._ttl,
+            "size": size,
+            "ttl_seconds": ttl,
         }
 
 

--- a/tests/test_agg_reports_saga.py
+++ b/tests/test_agg_reports_saga.py
@@ -319,6 +319,7 @@ class TestInspectAggregateReport:
                                 mock_logger,
                                 query_type="SpotPrice",
                             )
+                            mock_get_query.assert_called_once_with(sample_aggregate_report.query_data)
 
     @pytest.mark.asyncio
     async def test_inspect_should_not_pause(self, mock_logger, mock_config_watcher, sample_aggregate_report):

--- a/tests/test_agg_reports_saga.py
+++ b/tests/test_agg_reports_saga.py
@@ -296,7 +296,9 @@ class TestInspectAggregateReport:
                     with patch("layer_values_monitor.monitor.decode_hex_value") as mock_decode:
                         with patch("layer_values_monitor.monitor.is_disputable") as mock_is_disputable:
                             # Setup mocks
-                            mock_get_query.return_value = MagicMock()
+                            mock_query = MagicMock()
+                            mock_query.__class__.__name__ = "SpotPrice"
+                            mock_get_query.return_value = mock_query
                             mock_get_feed.return_value = MagicMock()
                             mock_fetch_value_cached.return_value = (100.0, None)
                             mock_decode.return_value = 130.0  # 30% difference
@@ -311,6 +313,12 @@ class TestInspectAggregateReport:
                             should_pause, reason = result
                             assert should_pause is True
                             assert "exceeds pause threshold" in reason
+                            mock_fetch_value_cached.assert_called_once_with(
+                                mock_get_feed.return_value,
+                                sample_aggregate_report.query_id,
+                                mock_logger,
+                                query_type="SpotPrice",
+                            )
 
     @pytest.mark.asyncio
     async def test_inspect_should_not_pause(self, mock_logger, mock_config_watcher, sample_aggregate_report):

--- a/tests/test_agg_reports_saga.py
+++ b/tests/test_agg_reports_saga.py
@@ -370,6 +370,29 @@ class TestInspectAggregateReport:
                     assert len(error_calls) > 0
 
     @pytest.mark.asyncio
+    async def test_inspect_zero_trusted_value_sends_alert(self, mock_logger, mock_config_watcher, sample_aggregate_report):
+        """Test inspection when the trusted value is zero for a percentage query."""
+        with patch("layer_values_monitor.monitor.get_query") as mock_get_query:
+            with patch("layer_values_monitor.monitor.get_feed") as mock_get_feed:
+                with patch("layer_values_monitor.monitor.fetch_value_cached") as mock_fetch_value_cached:
+                    with patch("layer_values_monitor.monitor.generic_alert") as mock_alert:
+                        mock_query = MagicMock()
+                        mock_query.__class__.__name__ = "SpotPrice"
+                        mock_query.type = "SpotPrice"
+                        mock_get_query.return_value = mock_query
+                        mock_get_feed.return_value = MagicMock()
+                        mock_fetch_value_cached.return_value = (0.0, None)
+
+                        result = await inspect_aggregate_report(sample_aggregate_report, mock_config_watcher, mock_logger)
+
+                        assert result is None
+                        mock_alert.assert_called_once()
+                        alert_msg = mock_alert.call_args[0][0]
+                        assert sample_aggregate_report.query_id in alert_msg
+                        assert "Trusted value for" in alert_msg
+                        assert "was 0" in alert_msg
+
+    @pytest.mark.asyncio
     async def test_inspect_no_config(self, mock_logger, mock_config_watcher, sample_aggregate_report):
         """Test inspection with no configuration available."""
         # Mock config watcher to return no metrics

--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -276,6 +276,77 @@ async def test_inspect_reports_skips_deprecated_query_type(config_file):
 
 
 @pytest.mark.asyncio
+async def test_inspect_reports_sends_deprecated_alert_for_each_report_in_batch(config_file):
+    """Test that a deprecated query batch triggers one alert per report."""
+    from layer_values_monitor.monitor import inspect_reports
+
+    with open(config_file, "w") as f:
+        f.write("""
+            [global_defaults.equality]
+            alert_threshold = 1.0
+
+            [query_types]
+            trbbridge = { metric = "equality", handler = "trb_bridge", deprecated = true }
+            trbbridgev2 = { metric = "equality", handler = "trb_bridge" }
+        """)
+
+    time.sleep(0.1)
+    watcher = ConfigWatcher(config_file)
+
+    reports = [
+        NewReport(
+            query_type="TRBBridge",
+            query_data="0xabc",
+            query_id="0x123",
+            value="0xdeadbeef",
+            aggregate_method="weighted-median",
+            cyclelist="layer-1",
+            power="1000",
+            reporter="layer1testreporter",
+            timestamp="1234567890000",
+            meta_id="1",
+            tx_hash="0xtesthash",
+        ),
+        NewReport(
+            query_type="TRBBridge",
+            query_data="0xabc",
+            query_id="0x123",
+            value="0xcafebabe",
+            aggregate_method="weighted-median",
+            cyclelist="layer-1",
+            power="1000",
+            reporter="layer1secondreporter",
+            timestamp="1234567890001",
+            meta_id="2",
+            tx_hash="0xsecondhash",
+        ),
+    ]
+
+    disputes_q = asyncio.Queue()
+    mock_logger = Mock()
+
+    with patch("layer_values_monitor.monitor.deprecated_query_type_alert") as mock_alert:
+        await inspect_reports(reports, disputes_q, watcher, mock_logger)
+
+    assert mock_alert.call_count == 2
+    assert mock_alert.call_args_list[0].kwargs == {
+        "query_type": "TRBBridge",
+        "query_id": "0x123",
+        "report_value": "0xdeadbeef",
+        "reporter": "layer1testreporter",
+        "tx_hash": "0xtesthash",
+    }
+    assert mock_alert.call_args_list[1].kwargs == {
+        "query_type": "TRBBridge",
+        "query_id": "0x123",
+        "report_value": "0xcafebabe",
+        "reporter": "layer1secondreporter",
+        "tx_hash": "0xsecondhash",
+    }
+    assert disputes_q.empty()
+
+
+@pytest.mark.asyncio
 async def test_inspect_reports_does_not_skip_non_deprecated(config_file):
     """Test that non-deprecated types proceed to normal inspection."""
     from layer_values_monitor.monitor import inspect_reports

--- a/tests/test_double_check_dispute.py
+++ b/tests/test_double_check_dispute.py
@@ -8,7 +8,8 @@ The flow is:
 """
 
 import asyncio
-from unittest.mock import Mock, patch
+from dataclasses import replace
+from unittest.mock import AsyncMock, Mock, patch
 
 from layer_values_monitor.custom_types import Metrics, NewReport
 
@@ -163,6 +164,60 @@ async def test_immediate_refresh_clears_dispute(sample_report, metrics):
     assert "Second Trusted Value" in alert_msg
     assert str(cached_trusted_value) in alert_msg
     assert "99.5" in alert_msg
+
+
+@pytest.mark.asyncio
+async def test_evmcall_refresh_matching_bytes_cancels_dispute(sample_report):
+    """Test that EVMCall refreshes compare the inner bytes payload, not the full tuple."""
+    from layer_values_monitor.monitor import inspect_evmcall_path
+
+    evm_report = replace(
+        sample_report,
+        query_type="EVMCall",
+        value="0000000000000000000000000000000000000000000000000000000000000001",
+    )
+    evm_metrics = Metrics(
+        metric="equality",
+        alert_threshold=1.0,
+        warning_threshold=1.0,
+        minor_threshold=0.0,
+        major_threshold=0.0,
+        pause_threshold=0.0,
+    )
+
+    disputes_q = asyncio.Queue()
+    mock_logger = Mock()
+    mock_query = Mock()
+    mock_query.value_type.decode.return_value = (b"\x01", 1234567890)
+    mock_feed = Mock()
+
+    with patch("layer_values_monitor.monitor.get_query", return_value=mock_query):
+        with patch("layer_values_monitor.monitor.get_feed", return_value=mock_feed):
+            with patch(
+                "layer_values_monitor.monitor.fetch_value_cached",
+                new=AsyncMock(
+                    side_effect=[
+                        ((b"\x02", 1234567880), 9999999980),
+                        ((b"\x01", 1234567890), 9999999999),
+                    ]
+                ),
+            ):
+                with patch("layer_values_monitor.monitor.generic_alert") as mock_alert:
+                    with patch("layer_values_monitor.monitor.asyncio.sleep") as mock_sleep:
+                        await inspect_evmcall_path(
+                            [evm_report],
+                            disputes_q,
+                            evm_report.query_id,
+                            evm_report.query_data,
+                            evm_metrics,
+                            mock_logger,
+                        )
+            mock_sleep.assert_not_called()
+
+    assert disputes_q.empty()
+    mock_alert.assert_called_once()
+    alert_desc = mock_alert.call_args[1].get("description", "")
+    assert "NO DISPUTE SENT" in alert_desc
 
 
 @pytest.mark.asyncio
@@ -388,7 +443,7 @@ async def test_fetcher_error_on_immediate_refresh_cancels_dispute(sample_report,
         raise Exception("API Error")
 
     # Execute
-    with patch("layer_values_monitor.monitor.generic_alert"):
+    with patch("layer_values_monitor.monitor.generic_alert") as mock_alert:
         await inspect(
             sample_report,
             reported_value,
@@ -405,6 +460,11 @@ async def test_fetcher_error_on_immediate_refresh_cancels_dispute(sample_report,
 
     # Verify error was logged
     assert any("Error during dispute verification" in str(call) for call in mock_logger.error.call_args_list)
+    mock_alert.assert_called_once()
+    alert_msg = mock_alert.call_args[0][0]
+    alert_desc = mock_alert.call_args[1].get("description", "")
+    assert "VERIFICATION FAILED" in alert_desc
+    assert "Fresh trusted value verification failed" in alert_msg
 
 
 @pytest.mark.asyncio

--- a/tests/test_double_check_dispute.py
+++ b/tests/test_double_check_dispute.py
@@ -166,6 +166,118 @@ async def test_immediate_refresh_clears_dispute(sample_report, metrics):
 
 
 @pytest.mark.asyncio
+async def test_zero_cached_trusted_value_sends_alert_and_skips_dispute(sample_report, metrics):
+    """Test that a zero cached trusted value sends an alert and skips inspection."""
+    from layer_values_monitor.monitor import inspect
+
+    disputes_q = asyncio.Queue()
+    mock_logger = Mock()
+    mock_query = Mock()
+    mock_query.type = "SpotPrice"
+
+    with patch("layer_values_monitor.monitor.generic_alert") as mock_alert:
+        await inspect(
+            sample_report,
+            100.0,
+            0.0,
+            disputes_q,
+            metrics,
+            mock_logger,
+            query=mock_query,
+            trusted_value_fetcher=None,
+        )
+
+    assert disputes_q.empty()
+    mock_alert.assert_called_once()
+    alert_msg = mock_alert.call_args[0][0]
+    alert_desc = mock_alert.call_args[1].get("description", "")
+    assert sample_report.query_id in alert_msg
+    assert "Trusted value for" in alert_msg
+    assert "was 0" in alert_msg
+    assert "TRUSTED VALUE WAS 0" in alert_desc
+
+
+@pytest.mark.asyncio
+async def test_zero_immediate_refresh_value_sends_alert_and_cancels_dispute(sample_report, metrics):
+    """Test that a zero immediate refresh value sends an alert and cancels the dispute."""
+    from layer_values_monitor.monitor import inspect
+
+    async def mock_fetcher():
+        return (0.0, 1234567890)
+
+    disputes_q = asyncio.Queue()
+    mock_logger = Mock()
+    mock_query = Mock()
+    mock_query.type = "SpotPrice"
+
+    with patch("layer_values_monitor.monitor.generic_alert") as mock_alert:
+        with patch("layer_values_monitor.monitor.asyncio.sleep") as mock_sleep:
+            await inspect(
+                sample_report,
+                100.0,
+                90.0,
+                disputes_q,
+                metrics,
+                mock_logger,
+                query=mock_query,
+                trusted_value_fetcher=mock_fetcher,
+            )
+            mock_sleep.assert_not_called()
+
+    assert disputes_q.empty()
+    mock_alert.assert_called_once()
+    alert_msg = mock_alert.call_args[0][0]
+    alert_desc = mock_alert.call_args[1].get("description", "")
+    assert sample_report.query_id in alert_msg
+    assert "Trusted value for" in alert_msg
+    assert "was 0" in alert_msg
+    assert "TRUSTED VALUE WAS 0" in alert_desc
+
+
+@pytest.mark.asyncio
+async def test_zero_final_refresh_value_sends_alert_and_cancels_dispute(sample_report, metrics):
+    """Test that a zero final refresh value sends an alert and cancels the dispute."""
+    from layer_values_monitor.monitor import inspect
+
+    fetch_call_count = 0
+
+    async def mock_fetcher():
+        nonlocal fetch_call_count
+        fetch_call_count += 1
+        if fetch_call_count == 1:
+            return (88.0, 1234567890)
+        return (0.0, 1234567891)
+
+    disputes_q = asyncio.Queue()
+    mock_logger = Mock()
+    mock_query = Mock()
+    mock_query.type = "SpotPrice"
+
+    with patch("layer_values_monitor.monitor.generic_alert") as mock_alert:
+        with patch("layer_values_monitor.monitor.asyncio.sleep", return_value=None):
+            await inspect(
+                sample_report,
+                100.0,
+                90.0,
+                disputes_q,
+                metrics,
+                mock_logger,
+                query=mock_query,
+                trusted_value_fetcher=mock_fetcher,
+            )
+
+    assert disputes_q.empty()
+    assert fetch_call_count == 2
+    mock_alert.assert_called_once()
+    alert_msg = mock_alert.call_args[0][0]
+    alert_desc = mock_alert.call_args[1].get("description", "")
+    assert sample_report.query_id in alert_msg
+    assert "Trusted value for" in alert_msg
+    assert "was 0" in alert_msg
+    assert "TRUSTED VALUE WAS 0" in alert_desc
+
+
+@pytest.mark.asyncio
 async def test_final_check_clears_dispute(sample_report, metrics):
     """Test that dispute is cancelled when final check doesn't cross threshold.
 

--- a/tests/test_double_check_dispute.py
+++ b/tests/test_double_check_dispute.py
@@ -158,6 +158,11 @@ async def test_immediate_refresh_clears_dispute(sample_report, metrics):
 
     # Alert should still be sent (alertable but not disputable after refresh)
     mock_alert.assert_called_once()
+    alert_msg = mock_alert.call_args[0][0]
+    assert "First Trusted Value" in alert_msg
+    assert "Second Trusted Value" in alert_msg
+    assert str(cached_trusted_value) in alert_msg
+    assert "99.5" in alert_msg
 
 
 @pytest.mark.asyncio

--- a/tests/test_is_disputable.py
+++ b/tests/test_is_disputable.py
@@ -38,6 +38,26 @@ def test_percentage_metric(reported_value, trusted_value, alert_threshold, dispu
         assert abs(result[2] - expected[2]) < 1e-10
 
 
+def test_percentage_metric_handles_zero_trusted_value():
+    """Test that zero trusted values are rejected for percentage metrics."""
+    zero_logger = MagicMock(spec=logging.Logger)
+
+    result = is_disputable("percentage", 0.1, 0.2, 100, 0, zero_logger)
+
+    assert result == (None, None, None)
+    zero_logger.error.assert_called_once()
+
+
+def test_percentage_metric_handles_matching_zero_values():
+    """Test that matching zero values are also rejected for percentage metrics."""
+    zero_logger = MagicMock(spec=logging.Logger)
+
+    result = is_disputable("percentage", 0.1, 0.2, 0, 0, zero_logger)
+
+    assert result == (None, None, None)
+    zero_logger.error.assert_called_once()
+
+
 @pytest.mark.parametrize(
     "reported_value,trusted_value,expected",
     [

--- a/tests/test_monitor_regressions.py
+++ b/tests/test_monitor_regressions.py
@@ -1,0 +1,134 @@
+"""Regression tests for monitor behavior changes."""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from layer_values_monitor.custom_types import Metrics, NewReport
+from layer_values_monitor.telliot_feeds import get_price_cache
+
+import pytest
+
+
+def make_spotprice_report() -> NewReport:
+    """Create a representative SpotPrice report."""
+    return NewReport(
+        query_type="SpotPrice",
+        query_data=(
+            "0000000000000000000000000000000000000000000000000000000000000040"
+            "0000000000000000000000000000000000000000000000000000000000000080"
+            "0000000000000000000000000000000000000000000000000000000000000009"
+            "53706f7450726963650000000000000000000000000000000000000000000000"
+            "00000000000000000000000000000000000000000000000000000000000000c0"
+            "0000000000000000000000000000000000000000000000000000000000000040"
+            "0000000000000000000000000000000000000000000000000000000000000080"
+            "0000000000000000000000000000000000000000000000000000000000000003"
+            "6574680000000000000000000000000000000000000000000000000000000000"
+            "0000000000000000000000000000000000000000000000000000000000000003"
+            "7573640000000000000000000000000000000000000000000000000000000000"
+        ),
+        query_id="0xa6f013ee236804827b77696d350e9f0ac3e879328f2a3021d473a0b778ad78ac",
+        value="0000000000000000000000000000000000000000000000000000000ba43b7400",
+        aggregate_method="weighted-median",
+        cyclelist="layer-1",
+        power="1000",
+        reporter="tellor1test",
+        timestamp="1234567890000",
+        meta_id="1",
+        tx_hash="0xtest",
+    )
+
+
+@pytest.mark.asyncio
+async def test_inspect_spotprice_path_alerts_on_stale_cache_before_refresh():
+    """A stale cached value should still trigger the staleness alert before refresh."""
+    from layer_values_monitor.monitor import inspect_spotprice_path
+
+    report = make_spotprice_report()
+    metrics = Metrics(
+        metric="percentage",
+        alert_threshold=0.01,
+        warning_threshold=0.02,
+        minor_threshold=0.05,
+        major_threshold=0.10,
+        pause_threshold=0.0,
+    )
+    config_watcher = MagicMock()
+    config_watcher.has_query_config.return_value = True
+    config_watcher.get_staleness_threshold.return_value = 540.0
+
+    cache = get_price_cache()
+    original_ttl = cache._ttl
+    original_override = cache._ttl_override
+    original_config_watcher = cache._config_watcher
+
+    try:
+        await cache.clear()
+        cache._ttl = 180.0
+        cache._ttl_override = None
+        cache._config_watcher = None
+
+        await cache.set(report.query_id, 99.0, time.time())
+        cache._cache[report.query_id].fetch_time -= 600.0
+
+        mock_query = MagicMock()
+        mock_query.asset = "ETH"
+        mock_query.currency = "USD"
+        mock_query.value_type.decode.return_value = 100.0
+
+        mock_feed = MagicMock()
+        mock_feed.source.fetch_new_datapoint = AsyncMock(return_value=(101.0, time.time()))
+
+        with patch("telliot_feeds.queries.query_catalog.query_catalog.find", return_value=[MagicMock()]):
+            with patch("layer_values_monitor.monitor.get_query", return_value=mock_query):
+                with patch("layer_values_monitor.monitor.get_feed", new=AsyncMock(return_value=mock_feed)):
+                    with patch("layer_values_monitor.monitor.inspect", new=AsyncMock()):
+                        with patch("layer_values_monitor.monitor.send_staleness_alert", new=AsyncMock()) as mock_alert:
+                            await inspect_spotprice_path(
+                                [report],
+                                asyncio.Queue(),
+                                config_watcher,
+                                report.query_id,
+                                report.query_data,
+                                report.query_type,
+                                metrics,
+                                MagicMock(),
+                            )
+
+        mock_alert.assert_awaited_once()
+    finally:
+        await cache.clear()
+        cache._ttl = original_ttl
+        cache._ttl_override = original_override
+        cache._config_watcher = original_config_watcher
+
+
+@pytest.mark.asyncio
+async def test_new_reports_queue_handler_counts_actual_reports_for_cache_logging():
+    """Cache stats logging should trigger based on total reports, not query IDs."""
+    from layer_values_monitor.monitor import new_reports_queue_handler
+
+    new_reports_q = asyncio.Queue()
+    disputes_q = asyncio.Queue()
+    config_watcher = MagicMock()
+    logger = MagicMock()
+
+    batch = {f"query_{i}": [MagicMock(), MagicMock()] for i in range(50)}
+    await new_reports_q.put(batch)
+
+    mock_cache = MagicMock()
+    mock_cache.get_stats = AsyncMock(
+        return_value={"hits": 7, "misses": 3, "hit_rate": "70.0%", "size": 4, "ttl_seconds": 180.0}
+    )
+
+    with patch("layer_values_monitor.monitor.inspect_reports", new=AsyncMock()):
+        with patch("layer_values_monitor.monitor.get_price_cache", return_value=mock_cache):
+            task = asyncio.create_task(new_reports_queue_handler(new_reports_q, disputes_q, config_watcher, logger))
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    assert any("Price cache stats" in str(call) for call in logger.info.call_args_list)

--- a/tests/test_price_cache.py
+++ b/tests/test_price_cache.py
@@ -180,6 +180,19 @@ class TestPriceCache:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_get_with_staleness_does_not_change_cache_stats(self, cache):
+        """Test that staleness inspection does not affect hit/miss counters."""
+        query_id = "test_query_stats"
+        await cache.set(query_id, 100.5, time.time())
+
+        await cache.get_with_staleness(query_id)
+        await cache.get_with_staleness("missing_query")
+
+        stats = await cache.get_stats()
+        assert stats["hits"] == 0
+        assert stats["misses"] == 0
+
+    @pytest.mark.asyncio
     async def test_get_age_returns_correct_age(self, cache):
         """Test that get_age returns the correct age in seconds."""
         query_id = "test_query_age"

--- a/tests/test_price_cache.py
+++ b/tests/test_price_cache.py
@@ -249,6 +249,27 @@ class TestPerQueryTTL:
         ttl = cache._get_ttl_for_query("any_query", "spotprice")
         assert ttl == 180.0  # Should use default
 
+    def test_global_ttl_uses_latest_config_without_query_type(self, cache_with_config, mock_config_watcher):
+        """Test that default TTL follows live config changes when no override is set."""
+        assert cache_with_config._get_ttl_for_query("any_query") == 180.0
+        assert cache_with_config._get_staleness_threshold("any_query") == 540.0
+
+        mock_config_watcher.get_check_interval.return_value = 60.0
+        mock_config_watcher.get_staleness_threshold.return_value = 180.0
+
+        assert cache_with_config._get_ttl_for_query("any_query") == 60.0
+        assert cache_with_config._get_staleness_threshold("any_query") == 180.0
+
+    def test_ttl_override_beats_reloaded_config_defaults(self, cache_with_config, mock_config_watcher):
+        """Test that explicit TTL overrides are not replaced by config defaults."""
+        cache_with_config._ttl = 45.0
+        cache_with_config._ttl_override = 45.0
+        mock_config_watcher.get_check_interval.return_value = 60.0
+        mock_config_watcher.get_staleness_threshold.return_value = 180.0
+
+        assert cache_with_config._get_ttl_for_query("any_query") == 45.0
+        assert cache_with_config._get_staleness_threshold("any_query") == 135.0
+
 
 class TestFetchValueCached:
     """Test cases for fetch_value_cached function."""
@@ -389,12 +410,14 @@ class TestGlobalCache:
     def test_set_cache_ttl(self):
         """Test setting the cache TTL."""
         original_ttl = get_price_cache()._ttl
+        original_override = get_price_cache()._ttl_override
         try:
             set_cache_ttl(60.0)
             assert get_price_cache()._ttl == 60.0
         finally:
-            # Restore original TTL
-            set_cache_ttl(original_ttl)
+            # Restore original TTL state without forcing a new override.
+            get_price_cache()._ttl = original_ttl
+            get_price_cache()._ttl_override = original_override
 
     def test_initialize_cache_with_config(self):
         """Test initializing cache with config watcher."""
@@ -403,8 +426,10 @@ class TestGlobalCache:
 
         original_ttl = get_price_cache()._ttl
         original_config = get_price_cache()._config_watcher
+        original_override = get_price_cache()._ttl_override
 
         try:
+            get_price_cache()._ttl_override = None
             initialize_cache_with_config(mock_config)
 
             cache = get_price_cache()
@@ -414,6 +439,7 @@ class TestGlobalCache:
             # Restore original state
             get_price_cache()._ttl = original_ttl
             get_price_cache()._config_watcher = original_config
+            get_price_cache()._ttl_override = original_override
 
 
 class TestCacheWithQueryType:

--- a/tests/test_price_cache.py
+++ b/tests/test_price_cache.py
@@ -107,12 +107,13 @@ class TestPriceCache:
             await asyncio.sleep(0.01)  # Small delay to ensure different fetch times
 
         # Cache should have evicted some entries
-        stats = cache.get_stats()
+        stats = await cache.get_stats()
         assert stats["size"] <= 10
 
-    def test_cache_stats(self, cache):
+    @pytest.mark.asyncio
+    async def test_cache_stats(self, cache):
         """Test cache statistics."""
-        stats = cache.get_stats()
+        stats = await cache.get_stats()
         assert "hits" in stats
         assert "misses" in stats
         assert "hit_rate" in stats
@@ -132,7 +133,7 @@ class TestPriceCache:
         await cache.get(query_id)
         await cache.get(query_id)
 
-        stats = cache.get_stats()
+        stats = await cache.get_stats()
         assert stats["hits"] == 2
         assert stats["misses"] == 1
         assert "66.7%" in stats["hit_rate"]

--- a/tests/test_price_cache.py
+++ b/tests/test_price_cache.py
@@ -300,6 +300,46 @@ class TestFetchValueCached:
         assert result1[0] == result2[0]
 
     @pytest.mark.asyncio
+    async def test_concurrent_misses_share_one_api_call(self, mock_logger):
+        """Test that concurrent cache misses share a single API fetch."""
+        cache = get_price_cache()
+        await cache.clear()
+
+        query_id = f"test_query_concurrent_{time.time()}"
+        mock_feed = MagicMock()
+
+        async def slow_fetch():
+            await asyncio.sleep(0.05)
+            return (100.5, time.time())
+
+        mock_feed.source.fetch_new_datapoint = AsyncMock(side_effect=slow_fetch)
+
+        results = await asyncio.gather(*[fetch_value_cached(mock_feed, query_id, mock_logger) for _ in range(5)])
+
+        assert mock_feed.source.fetch_new_datapoint.call_count == 1
+        assert all(result == results[0] for result in results)
+
+    @pytest.mark.asyncio
+    async def test_failed_shared_fetch_can_retry(self, mock_logger):
+        """Test that a failed shared fetch clears in-flight state for retries."""
+        cache = get_price_cache()
+        await cache.clear()
+
+        query_id = f"test_query_retry_{time.time()}"
+        feed = MagicMock()
+
+        with patch(
+            "layer_values_monitor.telliot_feeds.fetch_value",
+            new=AsyncMock(side_effect=[None, (100.5, 1234567890.0)]),
+        ) as mock_fetch_value:
+            first_results = await asyncio.gather(*[fetch_value_cached(feed, query_id, mock_logger) for _ in range(2)])
+            second_result = await fetch_value_cached(feed, query_id, mock_logger)
+
+        assert first_results == [None, None]
+        assert second_result == (100.5, 1234567890.0)
+        assert mock_fetch_value.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_force_refresh_bypasses_cache(self, mock_logger):
         """Test that force_refresh bypasses the cache."""
         # Clear cache first

--- a/tests/test_trb_bridge.py
+++ b/tests/test_trb_bridge.py
@@ -1,5 +1,9 @@
 """Tests for TRBBridge monitoring functionality."""
 
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from layer_values_monitor.custom_types import Metrics, NewReport
 from layer_values_monitor.trb_bridge import decode_query_data, decode_report_value, get_trb_bridge_trusted_value
 
 import pytest
@@ -160,3 +164,48 @@ class TestTRBBridgeDecoding:
         assert result[1] == "tellor17gc67q05d5rgsz9caznm0s7s5eazwg2e3fkk8e"
         assert result[2] == 1000000000000000000
         assert result[3] == 50000000000000000
+
+
+@pytest.mark.asyncio
+async def test_inspect_trbbridge_reports_defaults_to_chain_id_one(monkeypatch):
+    """Test that bridge inspection defaults to chain ID 1 when unset."""
+    from layer_values_monitor.monitor import inspect_trbbridge_reports
+
+    monkeypatch.setenv("TRBBRIDGE_CONTRACT_ADDRESS", "0x62733e63499a25E35844c91275d4c3bdb159D29d")
+    monkeypatch.delenv("TRBBRIDGE_CHAIN_ID", raising=False)
+
+    report = NewReport(
+        query_type="TRBBridge",
+        query_data="0xabc",
+        query_id="0x123",
+        value="0xdeadbeef",
+        aggregate_method="weighted-median",
+        cyclelist="layer-1",
+        power="1000",
+        reporter="layer1testreporter",
+        timestamp="1234567890000",
+        meta_id="1",
+        tx_hash="0xtesthash",
+    )
+    metrics = Metrics(
+        metric="equality",
+        alert_threshold=1.0,
+        warning_threshold=1.0,
+        minor_threshold=0.0,
+        major_threshold=0.0,
+        pause_threshold=0.0,
+    )
+    logger = MagicMock()
+
+    with patch(
+        "layer_values_monitor.monitor.decode_report_value",
+        return_value=("0xsender", "layer1recipient", 1, 0),
+    ):
+        with patch(
+            "layer_values_monitor.monitor.get_trb_bridge_trusted_value",
+            new=AsyncMock(return_value=("0xsender", "layer1recipient", 1, 0)),
+        ) as mock_get_trusted_value:
+            with patch("layer_values_monitor.monitor.inspect", new=AsyncMock()):
+                await inspect_trbbridge_reports([report], asyncio.Queue(), report.query_id, metrics, logger)
+
+    assert mock_get_trusted_value.await_args.args[2] == 1


### PR DESCRIPTION
Codex 5.3 extra high audit results 

645affc show refreshed trusted value in alert if second check stops dispute from being sent
aa30f60 use per query cache settings for aggregate report inspection
cc2d9bd if trusted value is 0, get an alert, no dispute or crash
acea6d2 use same cache for concurrent calls
1cf7856 set up config watcher for price cache
3373211 make cache stats async
bb8d458 fix double count cache hits from get and get_with_staleness
d843e64 remove redundant get query call
1d037fd audit reports
35c4b0c fix evmcall refreshed check, report cache counting, fresh value verification failure message