### PR TITLE
All logging goes to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,25 @@ uv run layer-values-monitor
 
 ## Environment Variables
 
-### Required
+### Required: Layer Node
 - `URI` - Layer node endpoint (e.g., `localhost:26657`)
 - `CHAIN_ID` - Layer chain ID (e.g., `layertest-5`)
-- `MONITOR_NAME` - Monitor instance name
-- `DISCORD_WEBHOOK_URL_1` - Discord webhook for alerts
-- `MAX_TABLE_ROWS` - Max CSV rows before rotation (default: `1000000`)
 
-### Dispute Configuration
-- `LAYER_BINARY_PATH` - Path to layerd binary
+### Required: Dispute Transactions
+These can be set in `.env` or passed as positional CLI arguments.
+- `LAYER_BINARY_PATH` - Path to `layerd` binary
 - `LAYER_KEY_NAME` - Keyring key name
 - `LAYER_KEYRING_BACKEND` - Keyring backend (e.g., `test`)
-- `LAYER_KEYRING_DIR` - Keyring directory (e.g., `~/.layer`)
+- `LAYER_KEYRING_DIR` - Keyring directory (e.g., `/home/<USERNAME>/.layer`)
+
+### Alerts
+- `DISCORD_WEBHOOK_URL_1` - Primary Discord webhook for alerts
+- `DISCORD_WEBHOOK_URL_2`, `DISCORD_WEBHOOK_URL_3` - Optional additional webhooks
+- `MONITOR_NAME` - Monitor instance name shown in alerts (default: `LVM`)
+
+### Optional Runtime Settings
+- `MAX_TABLE_ROWS` - Max CSV rows before rotation (default: `100000`)
+- `MAX_CATCHUP_BLOCKS` - Max blocks to process on reconnect (default: `15`)
 - `PAYFROM_BOND` - Pay from bond vs balance (default: `false`)
 
 ### EVM RPC Configuration
@@ -54,22 +61,20 @@ uv run layer-values-monitor
 **Advanced (Custom/Backup):**
 - `EVM_RPC_URLS_<CHAIN_ID>` - Comma-separated RPC URLs per chain
   - Example: `EVM_RPC_URLS_1="https://ethrpc1.com,https://ethrpc2.com"`
-  - Example: `EVM_RPC_URLS_137="https://polygonrpc1.com"`
+  - Example: `EVM_RPC_URLS_11155111="https://sepolia1.com,https://sepolia2.com"`
 
 ### TRB Bridge Monitoring
-- `TRBBRIDGE_CONTRACT_ADDRESS` - Bridge contract address (TRBBridge)
-- `TRBBRIDGEV2_CONTRACT_ADDRESS` - Bridge contract address (TRBBridgeV2)
-- `TRBBRIDGE_CHAIN_ID` - Bridge chain ID, shared by both versions (default: `11155111`)
+Required only when monitoring TRBBridge/TRBBridgeV2 query types.
+- `TRBBRIDGE_CONTRACT_ADDRESS` - Bridge contract address for TRBBridge
+- `TRBBRIDGEV2_CONTRACT_ADDRESS` - Bridge contract address for TRBBridgeV2
+- `TRBBRIDGE_CHAIN_ID` - Bridge chain ID, shared by both versions (code default: `1`; set `11155111` for Sepolia)
 
 ### Saga Guardian (Contract Pausing)
+Required only when starting with `--enable-saga-guard`.
 - `SAGA_RPC_URLS` - Comma-separated Saga RPC URLs
 - `SAGA_PRIVATE_KEY` - Guardian wallet private key
-- `SAGA_IMMEDIATE_PAUSE_THRESHOLD` - Power % for immediate pause (default: `0.66`)
-- `SAGA_DELAYED_PAUSE_THRESHOLD` - Power % for delayed pause (default: `0.33`)
-
-### Other
-- `MAX_CATCHUP_BLOCKS` - Max blocks to process on reconnect (default: `15`)
-- `DISCORD_WEBHOOK_URL_2`, `DISCORD_WEBHOOK_URL_3` - Additional webhooks
+- `SAGA_IMMEDIATE_PAUSE_THRESHOLD` - Power % for immediate pause (default: `0.66666666666`)
+- `SAGA_DELAYED_PAUSE_THRESHOLD` - Power % for delayed pause (default: `0.3333333333`)
 
 ## Configuration (config.toml)
 
@@ -125,8 +130,14 @@ uv run layer-values-monitor
 uv run layer-values-monitor [OPTIONS]
 ```
 
+You can provide dispute transaction settings through `.env`, or pass them positionally:
+```sh
+uv run layer-values-monitor /home/<USERNAME>/layerd <KEY_NAME> <KEYRING_BACKEND> /home/<USERNAME>/.layer
+```
+
 ### Flags
 - `--enable-saga-guard` - Enable contract pausing for aggregate reports
+- `--check-interval <SECONDS>` - Override the trusted value cache/check interval from `config.toml`
 
 ## Common Configurations
 
@@ -159,8 +170,8 @@ Pauses datafeed contracts when aggregate reports are incorrect.
 - `datafeed_ca` configured for each query in config.toml
 
 ### Power-Based Logic
-- **Immediate pause**: Triggered when bad aggregate report power > `SAGA_IMMEDIATE_PAUSE_THRESHOLD` (default 66%)
-- **Delayed pause**: Triggered when bad aggregate report power > `SAGA_DELAYED_PAUSE_THRESHOLD` (default 33%)
+- **Immediate pause**: Triggered when bad aggregate report power > `SAGA_IMMEDIATE_PAUSE_THRESHOLD` (default `0.66666666666`)
+- **Delayed pause**: Triggered when bad aggregate report power > `SAGA_DELAYED_PAUSE_THRESHOLD` (default `0.3333333333`)
 
 Power calculated as % of total non-jailed reporter power.
 
@@ -178,7 +189,11 @@ uv run ruff format
 ```
 
 ### Logs
-All log files will rotate to new file after they recach 52mb
-- **Console**: INFO and above, captured in terminal_log.log
-- **File**: full logs are in debug_log.log
+Runtime logs are written to standard output so service managers such as journald can capture them.
+- **stdout/journald**: full application logs, including debug records
+- **terminal_log.log**: local rotating backup of INFO and above
+- **debug_log.log**: local rotating backup of DEBUG and above
+- **Rotation**: text logs rotate at 10 MB and keep 5 backups per log type
 - **CSV Data**: `logs/table_*.csv`
+
+For systemd deployments, use `StandardOutput=journal` and `StandardError=journal` so logs can be managed with `journalctl`.

--- a/README.md
+++ b/README.md
@@ -191,9 +191,11 @@ uv run ruff format
 
 ### Logs
 Runtime logs are written to standard output so service managers such as journald can capture them.
-- **stdout/journald**: full application logs, including debug records
+- **stdout/journald**: operational logs at `LVM_JOURNAL_LOG_LEVEL` and above (default: `INFO`)
+- **Normal operation summaries**: per-block report details are debug-only; journald gets compact summaries every `LVM_OPERATIONAL_SUMMARY_INTERVAL_SECONDS` seconds (default: `300`)
+- **Warnings/errors/failures**: alerts, stale cache warnings, unsupported queries, dispute failures, and exceptions continue to appear in journald
 - **Local text logs**: disabled by default
-- **LVM_ENABLE_FILE_LOGS=true**: also writes `terminal_log.log` (INFO and above) and `debug_log.log` (DEBUG and above) in the project folder
+- **LVM_ENABLE_FILE_LOGS=true**: also writes `terminal_log.log` (INFO and above) and `debug_log.log` (`LVM_DEBUG_FILE_LOG_LEVEL`, default `DEBUG`) in the project folder
 - **Rotation**: optional text logs rotate at 10 MB and keep 5 backups per log type
 - **CSV Data**: `logs/table_*.csv`
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ These can be set in `.env` or passed as positional CLI arguments.
 - `MAX_TABLE_ROWS` - Max CSV rows before rotation (default: `100000`)
 - `MAX_CATCHUP_BLOCKS` - Max blocks to process on reconnect (default: `15`)
 - `PAYFROM_BOND` - Pay from bond vs balance (default: `false`)
+- `LVM_ENABLE_FILE_LOGS` - Also write local `.log` files in the project folder when set to `true`, `1`, or `yes` (default: disabled)
 
 ### EVM RPC Configuration
 **Simple (Infura):**
@@ -191,9 +192,9 @@ uv run ruff format
 ### Logs
 Runtime logs are written to standard output so service managers such as journald can capture them.
 - **stdout/journald**: full application logs, including debug records
-- **terminal_log.log**: local rotating backup of INFO and above
-- **debug_log.log**: local rotating backup of DEBUG and above
-- **Rotation**: text logs rotate at 10 MB and keep 5 backups per log type
+- **Local text logs**: disabled by default
+- **LVM_ENABLE_FILE_LOGS=true**: also writes `terminal_log.log` (INFO and above) and `debug_log.log` (DEBUG and above) in the project folder
+- **Rotation**: optional text logs rotate at 10 MB and keep 5 backups per log type
 - **CSV Data**: `logs/table_*.csv`
 
 For systemd deployments, use `StandardOutput=journal` and `StandardError=journal` so logs can be managed with `journalctl`.

--- a/env.example
+++ b/env.example
@@ -63,4 +63,6 @@ SAGA_DELAYED_PAUSE_THRESHOLD=0.3333333333
 
 # === LOGGING ===
 # Runtime logs are written to stdout for journald.
-# debug_log.log and terminal_log.log are fixed-size local backups configured in code.
+# Set to true to also save fixed-size local backups in the project folder.
+LVM_ENABLE_FILE_LOGS=false
+# When enabled, debug_log.log and terminal_log.log rotate at 10 MB with 5 backups.

--- a/env.example
+++ b/env.example
@@ -2,56 +2,65 @@
 # LAYER VALUES MONITOR ENV CONFIGURATION
 # ===================================================================
 
-MONITOR_NAME=""
-
-# === LAYER NODE CONNECTION ===
+# === REQUIRED: LAYER NODE CONNECTION ===
 URI=localhost:26657
 CHAIN_ID=layertest-5
 
-# === NOTIFICATIONS ===
-# up to 3 discord webhooks for sending alerts
+# === REQUIRED: DISPUTE TRANSACTION CONFIGURATION ===
+# These can also be passed as positional CLI arguments.
+LAYER_BINARY_PATH="/home/<USERNAME>/layerd"
+LAYER_KEY_NAME="<KEY_NAME>"
+LAYER_KEYRING_BACKEND="test"
+LAYER_KEYRING_DIR="/home/<USERNAME>/.layer"
+
+# === REQUIRED FOR ALERTS ===
+# DISCORD_WEBHOOK_URL_1 is required when sending Discord alerts.
+# DISCORD_WEBHOOK_URL_2 and DISCORD_WEBHOOK_URL_3 are optional mirrors.
 DISCORD_WEBHOOK_URL_1=""
-DISCORD_WEBHOOK_URL_2=""  # optional
-DISCORD_WEBHOOK_URL_3=""  # optional
+DISCORD_WEBHOOK_URL_2=""
+DISCORD_WEBHOOK_URL_3=""
 
-# === FILE ROTATION ===
-# maximum number of rows before rotating CSV files
-MAX_TABLE_ROWS=1000000
+# === OPTIONAL: MONITOR IDENTITY ===
+# Defaults to "LVM" if unset.
+MONITOR_NAME="LVM"
 
-# === CATCHUP BEHAVIOR ===
-# maximum number of blocks to process if catching up on blocks
+# === OPTIONAL: LOCAL CSV DATA ROTATION ===
+# Defaults to 100000 rows if unset.
+MAX_TABLE_ROWS=100000
+
+# === OPTIONAL: CATCHUP BEHAVIOR ===
+# Defaults to 15 blocks if unset.
 MAX_CATCHUP_BLOCKS=15
 
-# === DISPUTE CONFIGURATION ===
-# layer binary and keyring configuration for sending dispute transactions
-LAYER_BINARY_PATH="/Users/my/path/to/layerd"
-LAYER_KEY_NAME="MyKey"
-LAYER_KEYRING_BACKEND="test"
-LAYER_KEYRING_DIR="~/.layer"
+# === OPTIONAL: DISPUTE PAYMENT SOURCE ===
+# Accepted truthy values: true, 1, yes. Defaults to false if unset.
 PAYFROM_BOND=false
 
-# === TRBBRIDGE MONITORING ===
-# configuration for TRBBridge/TRBBridgeV2 report monitoring
+# === OPTIONAL: TRBBRIDGE MONITORING ===
+# Required only when monitoring TRBBridge/TRBBridgeV2 query types.
+# TRBBRIDGE_CHAIN_ID defaults to 1 if unset; set 11155111 for Sepolia.
 TRBBRIDGE_CONTRACT_ADDRESS="0x62733e63499a25E35844c91275d4c3bdb159D29d"
 TRBBRIDGEV2_CONTRACT_ADDRESS="0x55355157703A44f7516FBB831333317E98944e32"
 TRBBRIDGE_CHAIN_ID=11155111
 
-# === EVM RPC ENDPOINTS ===
+# === OPTIONAL: EVM RPC ENDPOINTS ===
+# Chain-specific RPC URLs take precedence over INFURA_API_KEY.
+# Use comma-separated URLs for primary + failover endpoints.
+EVM_RPC_URLS_1="https://mainnet.example-rpc.com,https://mainnet-backup.example-rpc.com"
+EVM_RPC_URLS_11155111="https://sepolia.example-rpc.com,https://sepolia-backup.example-rpc.com"
 
-# Ethereum RPC URL(s)
-# automatically falls back if primary fails
-EVM_RPC_URLS_1="primary,backup1,backup2"
+# INFURA_API_KEY is an optional fallback for chain IDs 1 and 11155111.
+INFURA_API_KEY=""
 
-# Infura API KEY fot opt. multichain backup
-# Note: Chain specific URL(s) takes precedence over INFURA_API_KEY
-INFURA_API_KEY="your-infura-api-key"
-
-# === SAGA GUARDIAN (optional) ===
-# enable contract pausing functionality with --enable-saga-guard flag
-# comma-separated list
-SAGA_RPC_URLS="https://primary-rpc.saga.xyz/,https://backup-rpc.saga.xyz/"
+# === OPTIONAL: SAGA GUARDIAN ===
+# Required only when starting with --enable-saga-guard.
+SAGA_RPC_URLS="https://primary-rpc.saga.xyz,https://backup-rpc.saga.xyz"
 SAGA_PRIVATE_KEY=""
 
-# Aggregate report power thresholds (as decimal, e.g., 0.66 = 66%)
-SAGA_IMMEDIATE_PAUSE_THRESHOLD=0.66  # default: 66% of non-jailed reporting power
-SAGA_DELAYED_PAUSE_THRESHOLD=0.33    # default: 33% of non-jailed reporting power
+# Aggregate report power thresholds. Defaults shown below.
+SAGA_IMMEDIATE_PAUSE_THRESHOLD=0.66666666666
+SAGA_DELAYED_PAUSE_THRESHOLD=0.3333333333
+
+# === LOGGING ===
+# Runtime logs are written to stdout for journald.
+# debug_log.log and terminal_log.log are fixed-size local backups configured in code.

--- a/env.example
+++ b/env.example
@@ -62,7 +62,13 @@ SAGA_IMMEDIATE_PAUSE_THRESHOLD=0.66666666666
 SAGA_DELAYED_PAUSE_THRESHOLD=0.3333333333
 
 # === LOGGING ===
-# Runtime logs are written to stdout for journald.
+# Runtime logs are written to stdout for journald. Defaults keep journald operational
+# while debug details remain available through local file logs when enabled.
+LVM_JOURNAL_LOG_LEVEL=INFO
 # Set to true to also save fixed-size local backups in the project folder.
 LVM_ENABLE_FILE_LOGS=false
+# Debug file verbosity when file logs are enabled.
+LVM_DEBUG_FILE_LOG_LEVEL=DEBUG
+# Emit compact normal-operation report summaries at this interval.
+LVM_OPERATIONAL_SUMMARY_INTERVAL_SECONDS=300
 # When enabled, debug_log.log and terminal_log.log rotate at 10 MB with 5 backups.

--- a/lvm.service.example
+++ b/lvm.service.example
@@ -10,6 +10,8 @@ WorkingDirectory=/home/<USERNAME>/layer-values-monitor
 Environment=PATH=/home/<USERNAME>/.local/bin
 Environment=PYTHONPATH=/home/<USERNAME>/layer-values-monitor/.venv
 ExecStart=/bin/bash -c "uv run layer-values-monitor /home/<USERNAME>/layerd <ACCOUNT_NAME> <KEYRING_BACKEND> /home/<USERNAME>/.layer --global-percentage-alert-threshold 0.10" ...
+StandardOutput=journal
+StandardError=journal
 Restart=always
 RestartSec=60
 

--- a/src/layer_values_monitor/dispute.py
+++ b/src/layer_values_monitor/dispute.py
@@ -151,7 +151,7 @@ async def propose_msg(
         signed_tx = json.loads(stdout.decode())
         code = signed_tx["code"]
         if code != 0:
-            print(signed_tx)
+            logger.debug(f"failed dispute signed tx: {signed_tx}")
             logger.error(f"failed to execute dispute msg: {signed_tx['raw_log']}")
             return None
         logger.info(f"dispute msg executed successfully: {signed_tx['txhash']}")

--- a/src/layer_values_monitor/logger.py
+++ b/src/layer_values_monitor/logger.py
@@ -1,19 +1,31 @@
 """Logger."""
 
 import logging
+import os
 import sys
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
+from dotenv import load_dotenv
+
 LOG_MAX_BYTES = 10 * 1024 * 1024
 LOG_BACKUP_COUNT = 5
-DEBUG_LOG_FILE = "debug_log.log"
-TERMINAL_LOG_FILE = "terminal_log.log"
+ENABLE_FILE_LOGS_ENV = "LVM_ENABLE_FILE_LOGS"
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEBUG_LOG_FILE = PROJECT_ROOT / "debug_log.log"
+TERMINAL_LOG_FILE = PROJECT_ROOT / "terminal_log.log"
+
+load_dotenv()
 
 
-def _cleanup_stale_rotated_logs(log_file: str) -> None:
+def _file_logs_enabled() -> bool:
+    """Return whether local rotating text logs should be written."""
+    return os.getenv(ENABLE_FILE_LOGS_ENV, "").lower() in ("true", "1", "yes")
+
+
+def _cleanup_stale_rotated_logs(log_file: Path) -> None:
     """Remove rotated log backups beyond the configured retention count."""
-    log_path = Path(log_file)
+    log_path = log_file
     parent = log_path.parent if log_path.parent != Path("") else Path(".")
     prefix = f"{log_path.name}."
 
@@ -30,13 +42,11 @@ def _reset_handlers(configured_logger: logging.Logger) -> None:
         handler.close()
 
 
-for log_file in (DEBUG_LOG_FILE, TERMINAL_LOG_FILE):
-    _cleanup_stale_rotated_logs(log_file)
-
 debug_formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 terminal_formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+file_logs_enabled = _file_logs_enabled()
 
-# Package logger: captures all layer_values_monitor.* records and sends them to stdout + debug file.
+# Package logger: captures all layer_values_monitor.* records and sends them to stdout.
 package_logger = logging.getLogger("layer_values_monitor")
 _reset_handlers(package_logger)
 package_logger.setLevel(logging.DEBUG)
@@ -46,21 +56,23 @@ stdout_handler = logging.StreamHandler(sys.stdout)
 stdout_handler.setLevel(logging.DEBUG)
 stdout_handler.setFormatter(debug_formatter)
 
-debug_file_handler = RotatingFileHandler(
-    DEBUG_LOG_FILE,
-    maxBytes=LOG_MAX_BYTES,
-    backupCount=LOG_BACKUP_COUNT,
-)
-debug_file_handler.setLevel(logging.DEBUG)
-debug_file_handler.setFormatter(debug_formatter)
-
 package_logger.addHandler(stdout_handler)
-package_logger.addHandler(debug_file_handler)
+
+if file_logs_enabled:
+    _cleanup_stale_rotated_logs(DEBUG_LOG_FILE)
+    debug_file_handler = RotatingFileHandler(
+        DEBUG_LOG_FILE,
+        maxBytes=LOG_MAX_BYTES,
+        backupCount=LOG_BACKUP_COUNT,
+    )
+    debug_file_handler.setLevel(logging.DEBUG)
+    debug_file_handler.setFormatter(debug_formatter)
+    package_logger.addHandler(debug_file_handler)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-# Create a separate console logger for clean terminal output and terminal_log.log.
+# Create a separate console logger for clean terminal output.
 console_logger = logging.getLogger("console")
 _reset_handlers(console_logger)
 console_logger.setLevel(logging.INFO)
@@ -71,11 +83,13 @@ console_only_handler.setLevel(logging.INFO)
 console_only_handler.setFormatter(terminal_formatter)
 console_logger.addHandler(console_only_handler)
 
-full_file_handler = RotatingFileHandler(
-    TERMINAL_LOG_FILE,
-    maxBytes=LOG_MAX_BYTES,
-    backupCount=LOG_BACKUP_COUNT,
-)
-full_file_handler.setLevel(logging.INFO)
-full_file_handler.setFormatter(terminal_formatter)
-console_logger.addHandler(full_file_handler)
+if file_logs_enabled:
+    _cleanup_stale_rotated_logs(TERMINAL_LOG_FILE)
+    full_file_handler = RotatingFileHandler(
+        TERMINAL_LOG_FILE,
+        maxBytes=LOG_MAX_BYTES,
+        backupCount=LOG_BACKUP_COUNT,
+    )
+    full_file_handler.setLevel(logging.INFO)
+    full_file_handler.setFormatter(terminal_formatter)
+    console_logger.addHandler(full_file_handler)

--- a/src/layer_values_monitor/logger.py
+++ b/src/layer_values_monitor/logger.py
@@ -1,52 +1,81 @@
 """Logger."""
 
 import logging
+import sys
 from logging.handlers import RotatingFileHandler
+from pathlib import Path
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+LOG_MAX_BYTES = 10 * 1024 * 1024
+LOG_BACKUP_COUNT = 5
+DEBUG_LOG_FILE = "debug_log.log"
+TERMINAL_LOG_FILE = "terminal_log.log"
 
-# Debug file handler - captures everything
-debug_file_handler = RotatingFileHandler(
-    "debug_log.log",
-    maxBytes=50 * 1024 * 1024,  # 50MB
-    backupCount=20,
-)
-debug_file_handler.setLevel(logging.DEBUG)
 
-# Full file handler - captures INFO and above (what would go to terminal)
-full_file_handler = RotatingFileHandler(
-    "terminal_log.log",
-    maxBytes=50 * 1024 * 1024,  # 50MB
-    backupCount=20,
-)
-full_file_handler.setLevel(logging.INFO)
+def _cleanup_stale_rotated_logs(log_file: str) -> None:
+    """Remove rotated log backups beyond the configured retention count."""
+    log_path = Path(log_file)
+    parent = log_path.parent if log_path.parent != Path("") else Path(".")
+    prefix = f"{log_path.name}."
 
-# Console handler - only shows CRITICAL by default (we'll use custom console logs)
-console_handler = logging.StreamHandler()
-console_handler.setLevel(logging.CRITICAL)
+    for rotated_log in parent.glob(f"{log_path.name}.*"):
+        suffix = rotated_log.name.removeprefix(prefix)
+        if suffix.isdigit() and int(suffix) > LOG_BACKUP_COUNT:
+            rotated_log.unlink(missing_ok=True)
+
+
+def _reset_handlers(configured_logger: logging.Logger) -> None:
+    """Close existing handlers before configuring this module's loggers."""
+    for handler in configured_logger.handlers[:]:
+        configured_logger.removeHandler(handler)
+        handler.close()
+
+
+for log_file in (DEBUG_LOG_FILE, TERMINAL_LOG_FILE):
+    _cleanup_stale_rotated_logs(log_file)
 
 debug_formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 terminal_formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
 
+# Package logger: captures all layer_values_monitor.* records and sends them to stdout + debug file.
+package_logger = logging.getLogger("layer_values_monitor")
+_reset_handlers(package_logger)
+package_logger.setLevel(logging.DEBUG)
+package_logger.propagate = False
+
+stdout_handler = logging.StreamHandler(sys.stdout)
+stdout_handler.setLevel(logging.DEBUG)
+stdout_handler.setFormatter(debug_formatter)
+
+debug_file_handler = RotatingFileHandler(
+    DEBUG_LOG_FILE,
+    maxBytes=LOG_MAX_BYTES,
+    backupCount=LOG_BACKUP_COUNT,
+)
+debug_file_handler.setLevel(logging.DEBUG)
 debug_file_handler.setFormatter(debug_formatter)
-full_file_handler.setFormatter(terminal_formatter)
-console_handler.setFormatter(debug_formatter)
 
-logger.addHandler(debug_file_handler)
-logger.addHandler(console_handler)
+package_logger.addHandler(stdout_handler)
+package_logger.addHandler(debug_file_handler)
 
-# Create a separate console-only logger for clean terminal output
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+# Create a separate console logger for clean terminal output and terminal_log.log.
 console_logger = logging.getLogger("console")
+_reset_handlers(console_logger)
 console_logger.setLevel(logging.INFO)
-console_logger.propagate = False  # Don't propagate to root logger
+console_logger.propagate = False
 
-console_only_handler = logging.StreamHandler()
+console_only_handler = logging.StreamHandler(sys.stdout)
 console_only_handler.setLevel(logging.INFO)
-# Format: timestamp - level - message (no module name)
-console_formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
-console_only_handler.setFormatter(console_formatter)
+console_only_handler.setFormatter(terminal_formatter)
 console_logger.addHandler(console_only_handler)
 
-# Also add terminal_log.log to console_logger so it matches terminal output exactly
+full_file_handler = RotatingFileHandler(
+    TERMINAL_LOG_FILE,
+    maxBytes=LOG_MAX_BYTES,
+    backupCount=LOG_BACKUP_COUNT,
+)
+full_file_handler.setLevel(logging.INFO)
+full_file_handler.setFormatter(terminal_formatter)
 console_logger.addHandler(full_file_handler)

--- a/src/layer_values_monitor/logger.py
+++ b/src/layer_values_monitor/logger.py
@@ -11,6 +11,8 @@ from dotenv import load_dotenv
 LOG_MAX_BYTES = 10 * 1024 * 1024
 LOG_BACKUP_COUNT = 5
 ENABLE_FILE_LOGS_ENV = "LVM_ENABLE_FILE_LOGS"
+JOURNAL_LOG_LEVEL_ENV = "LVM_JOURNAL_LOG_LEVEL"
+DEBUG_FILE_LOG_LEVEL_ENV = "LVM_DEBUG_FILE_LOG_LEVEL"
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEBUG_LOG_FILE = PROJECT_ROOT / "debug_log.log"
 TERMINAL_LOG_FILE = PROJECT_ROOT / "terminal_log.log"
@@ -21,6 +23,23 @@ load_dotenv()
 def _file_logs_enabled() -> bool:
     """Return whether local rotating text logs should be written."""
     return os.getenv(ENABLE_FILE_LOGS_ENV, "").lower() in ("true", "1", "yes")
+
+
+def _get_log_level(env_var: str, default: int) -> int:
+    """Read a logging level from the environment."""
+    configured_level = os.getenv(env_var)
+    if not configured_level:
+        return default
+
+    normalized_level = configured_level.upper()
+    if normalized_level.isdigit():
+        return int(normalized_level)
+
+    level = logging.getLevelName(normalized_level)
+    if isinstance(level, int):
+        return level
+
+    return default
 
 
 def _cleanup_stale_rotated_logs(log_file: Path) -> None:
@@ -45,15 +64,17 @@ def _reset_handlers(configured_logger: logging.Logger) -> None:
 debug_formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 terminal_formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
 file_logs_enabled = _file_logs_enabled()
+journal_log_level = _get_log_level(JOURNAL_LOG_LEVEL_ENV, logging.INFO)
+debug_file_log_level = _get_log_level(DEBUG_FILE_LOG_LEVEL_ENV, logging.DEBUG)
 
-# Package logger: captures all layer_values_monitor.* records and sends them to stdout.
+# Package logger: captures all layer_values_monitor.* records.
 package_logger = logging.getLogger("layer_values_monitor")
 _reset_handlers(package_logger)
 package_logger.setLevel(logging.DEBUG)
 package_logger.propagate = False
 
 stdout_handler = logging.StreamHandler(sys.stdout)
-stdout_handler.setLevel(logging.DEBUG)
+stdout_handler.setLevel(journal_log_level)
 stdout_handler.setFormatter(debug_formatter)
 
 package_logger.addHandler(stdout_handler)
@@ -65,7 +86,7 @@ if file_logs_enabled:
         maxBytes=LOG_MAX_BYTES,
         backupCount=LOG_BACKUP_COUNT,
     )
-    debug_file_handler.setLevel(logging.DEBUG)
+    debug_file_handler.setLevel(debug_file_log_level)
     debug_file_handler.setFormatter(debug_formatter)
     package_logger.addHandler(debug_file_handler)
 
@@ -75,11 +96,11 @@ logger.setLevel(logging.DEBUG)
 # Create a separate console logger for clean terminal output.
 console_logger = logging.getLogger("console")
 _reset_handlers(console_logger)
-console_logger.setLevel(logging.INFO)
+console_logger.setLevel(logging.DEBUG)
 console_logger.propagate = False
 
 console_only_handler = logging.StreamHandler(sys.stdout)
-console_only_handler.setLevel(logging.INFO)
+console_only_handler.setLevel(journal_log_level)
 console_only_handler.setFormatter(terminal_formatter)
 console_logger.addHandler(console_only_handler)
 

--- a/src/layer_values_monitor/main.py
+++ b/src/layer_values_monitor/main.py
@@ -172,9 +172,9 @@ async def start() -> None:
 
     # Initialize config watcher
     config_path = Path(__file__).resolve().parents[2] / "config.toml"
-    logger.info(f"CONFIG DEBUG: Initializing ConfigWatcher with path: {config_path}")
+    logger.debug(f"CONFIG DEBUG: Initializing ConfigWatcher with path: {config_path}")
     config_watcher = ConfigWatcher(config_path)
-    logger.info("CONFIG DEBUG: Config watcher initialized")
+    logger.debug("CONFIG DEBUG: Config watcher initialized")
 
     # Initialize price cache with config (for per-query TTL support)
     initialize_cache_with_config(config_watcher)
@@ -189,20 +189,20 @@ async def start() -> None:
         console_logger.info(f"✅ Check interval: {config_watcher.get_check_interval()}s (from config)")
 
     # Log config summary (debug only)
-    logger.info("CONFIG DEBUG: Config summary:")
-    logger.info(f"CONFIG DEBUG: - Global defaults: {len(config_watcher.global_defaults)} metric types")
-    logger.info(f"CONFIG DEBUG: - Query types: {list(config_watcher.query_types.keys())}")
-    logger.info(f"CONFIG DEBUG: - Query configs: {list(config_watcher.query_configs.keys())}")
+    logger.debug("CONFIG DEBUG: Config summary:")
+    logger.debug(f"CONFIG DEBUG: - Global defaults: {len(config_watcher.global_defaults)} metric types")
+    logger.debug(f"CONFIG DEBUG: - Query types: {list(config_watcher.query_types.keys())}")
+    logger.debug(f"CONFIG DEBUG: - Query configs: {list(config_watcher.query_configs.keys())}")
 
     # Test config methods (debug only)
-    logger.info("CONFIG DEBUG: Testing config methods...")
+    logger.debug("CONFIG DEBUG: Testing config methods...")
     test_query_types = ["SpotPrice", "TRBBridge", "TRBBridgeV2", "EVMCall", "UnknownType"]
     for query_type in test_query_types:
         is_supported = config_watcher.is_supported_query_type(query_type)
-        logger.info(f"CONFIG DEBUG: - is_supported_query_type('{query_type}'): {is_supported}")
+        logger.debug(f"CONFIG DEBUG: - is_supported_query_type('{query_type}'): {is_supported}")
         if is_supported:
             query_type_info = config_watcher.get_query_type_info(query_type)
-            logger.info(f"CONFIG DEBUG:   - get_query_type_info('{query_type}'): {query_type_info}")
+            logger.debug(f"CONFIG DEBUG:   - get_query_type_info('{query_type}'): {query_type_info}")
 
     # Terminal summary of config
     supported_types = list(config_watcher.query_types.keys())

--- a/src/layer_values_monitor/main.py
+++ b/src/layer_values_monitor/main.py
@@ -39,7 +39,7 @@ def async_run(f: Any) -> Any:
         try:
             return asyncio.run(f(*args, **kwargs))
         except KeyboardInterrupt:
-            print("Exiting...")
+            console_logger.info("Exiting...")
 
     return wrapper
 
@@ -278,7 +278,7 @@ async def start() -> None:
 
         await asyncio.gather(*tasks)
     except asyncio.CancelledError:
-        print("shutting down running tasks")
+        console_logger.info("Shutting down running tasks")
         raise
 
 

--- a/src/layer_values_monitor/monitor.py
+++ b/src/layer_values_monitor/monitor.py
@@ -6,6 +6,7 @@ import logging
 import os
 import random
 import time
+from collections import Counter
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -44,6 +45,117 @@ from layer_values_monitor.utils import add_to_table, decode_hex_value
 
 import aiohttp
 import websockets
+
+DEFAULT_OPERATIONAL_SUMMARY_INTERVAL_SECONDS = 300.0
+
+
+def _get_float_env(env_var: str, default: float) -> float:
+    """Read a float from the environment."""
+    configured_value = os.getenv(env_var)
+    if configured_value is None:
+        return default
+
+    try:
+        return float(configured_value)
+    except ValueError:
+        return default
+
+
+OPERATIONAL_SUMMARY_INTERVAL_SECONDS = _get_float_env(
+    "LVM_OPERATIONAL_SUMMARY_INTERVAL_SECONDS",
+    DEFAULT_OPERATIONAL_SUMMARY_INTERVAL_SECONDS,
+)
+
+
+def _format_report_group_label(report: NewReport) -> str:
+    """Return a compact label for operational report summaries."""
+    query_type = report.query_type
+    if query_type.lower() != "spotprice":
+        return query_type
+
+    try:
+        query_obj = get_query(report.query_data)
+        if query_obj and hasattr(query_obj, "asset") and hasattr(query_obj, "currency"):
+            return f"{query_obj.asset.lower()}/{query_obj.currency.lower()}"
+    except Exception:
+        pass
+
+    return query_type
+
+
+def _format_report_batch_summary(reports_collections: dict[str, list[NewReport]]) -> str:
+    """Format a detailed single-batch summary for debug logs."""
+    summaries = []
+    for reports in reports_collections.values():
+        if not reports:
+            continue
+        summaries.append(f"{len(reports)} {_format_report_group_label(reports[0])}")
+
+    return ", ".join(summaries)
+
+
+class OperationalSummary:
+    """Collect normal-operation report counts and emit periodic summaries."""
+
+    def __init__(self, interval_seconds: float = OPERATIONAL_SUMMARY_INTERVAL_SECONDS) -> None:
+        """Initialize summary counters."""
+        self.interval_seconds = interval_seconds
+        self.last_logged_at = time.time()
+        self.report_count = 0
+        self.heights: set[int | str] = set()
+        self.query_counts: Counter[str] = Counter()
+
+    def record_report_batch(self, height: int | str | None, reports_collections: dict[str, list[NewReport]]) -> None:
+        """Record a processed batch of new reports."""
+        if height is not None:
+            self.heights.add(height)
+
+        for reports in reports_collections.values():
+            if not reports:
+                continue
+            label = _format_report_group_label(reports[0])
+            count = len(reports)
+            self.query_counts[label] += count
+            self.report_count += count
+
+    def maybe_log(self, logger: logging.Logger, now: float | None = None) -> None:
+        """Log a compact operational summary once enough time has elapsed."""
+        now = now if now is not None else time.time()
+        if self.report_count == 0 or now - self.last_logged_at < self.interval_seconds:
+            return
+
+        query_summary = ", ".join(f"{label}={count}" for label, count in self.query_counts.most_common())
+        logger.info(
+            f"Processed {self.report_count} reports across {len(self.heights)} heights"
+            f"{f': {query_summary}' if query_summary else ''}"
+        )
+        self.report_count = 0
+        self.heights.clear()
+        self.query_counts.clear()
+        self.last_logged_at = now
+
+
+async def _flush_new_report_batch(
+    reports_collections: dict[str, list[NewReport]],
+    current_height: int | None,
+    new_reports_q: asyncio.Queue,
+    summary: OperationalSummary,
+    logger: logging.Logger,
+    *,
+    reason: str,
+) -> None:
+    """Queue a batch of new reports and record normal-operation summary stats."""
+    if not reports_collections:
+        return
+
+    collected_height = current_height if current_height is not None else "unknown"
+    batch_summary = _format_report_batch_summary(reports_collections)
+    logger.debug(f"Processing reports from height {collected_height} ({reason}): {batch_summary}")
+    summary.record_report_batch(collected_height, reports_collections)
+    summary.maybe_log(logger)
+
+    await new_reports_q.put(dict(reports_collections))
+    reports_collections.clear()
 
 
 def format_dict_value(d: dict) -> str:
@@ -248,8 +360,7 @@ async def listen_to_websocket_events(
                     response = await websocket.recv()
                     parsed_response = json.loads(response)
 
-                    # Log EVERYTHING to see what we're getting
-                    logger.info(f"🔵 Raw WebSocket response: {json.dumps(parsed_response)[:500]}")
+                    logger.debug(f"Raw WebSocket response: {json.dumps(parsed_response)[:500]}")
 
                     await q.put(parsed_response)
 
@@ -322,6 +433,7 @@ async def raw_data_queue_handler(
     # current height being collected for - start as None to detect first height
     current_height = None
     last_batch_time = time.time()
+    operational_summary = OperationalSummary()
     while iterations < max_iterations:
         iterations += 1
         raw_data: dict[str, Any] = await raw_data_q.get()
@@ -352,8 +464,8 @@ async def raw_data_queue_handler(
         is_agg_report = "aggregate_report.query_id" in events or "aggregate_report.aggregate_power" in events
 
         if is_new_report:
-            logger.info(
-                f"✅ Detected new_report event with query_id: {events.get('new_report.query_id', ['unknown'])[0][:16]}"
+            logger.debug(
+                f"Detected new_report event with query_id: {events.get('new_report.query_id', ['unknown'])[0][:16]}"
             )
             try:
                 # get current height from event
@@ -376,32 +488,14 @@ async def raw_data_queue_handler(
                 # Process previous height's reports
                 if current_height is not None and height > current_height:
                     if len(reports_collections) > 0:
-                        # query type summary for logging
-                        query_type_summaries = []
-                        for _query_id, reports in reports_collections.items():
-                            query_type = reports[0].query_type
-                            count = len(reports)
-
-                            # if spot price, extract asset pair for logging
-                            if query_type.lower() == "spotprice":
-                                try:
-                                    query_obj = get_query(reports[0].query_data)
-                                    if query_obj and hasattr(query_obj, "asset") and hasattr(query_obj, "currency"):
-                                        asset_pair = f"{query_obj.asset.lower()}/{query_obj.currency.lower()}"
-                                        query_type_summaries.append(f"{count} {asset_pair}")
-                                    else:
-                                        query_type_summaries.append(f"{count} {query_type}")
-                                except Exception:
-                                    query_type_summaries.append(f"{count} {query_type}")
-                            else:
-                                query_type_summaries.append(f"{count} {query_type}")
-
-                        console_logger.info(
-                            f"Processing reports from height {current_height}: {', '.join(query_type_summaries)}"
+                        await _flush_new_report_batch(
+                            reports_collections,
+                            current_height,
+                            new_reports_q,
+                            operational_summary,
+                            logger,
+                            reason="height advanced",
                         )
-
-                        await new_reports_q.put(dict(reports_collections))
-                        reports_collections.clear()
                         last_batch_time = time.time()
 
                     current_height = height
@@ -433,32 +527,14 @@ async def raw_data_queue_handler(
                     logger.debug(f"timeout ({time.time() - last_batch_time:.1f}s > {BATCH_TIMEOUT}s)")
 
                 if should_process and len(reports_collections) > 0:
-                    # Build query type summary with asset pairs for spot prices
-                    query_type_summaries = []
-                    for _query_id, reports in reports_collections.items():
-                        query_type = reports[0].query_type
-                        count = len(reports)
-
-                        # For SpotPrice, try to extract asset pair
-                        if query_type.lower() == "spotprice":
-                            try:
-                                query_obj = get_query(reports[0].query_data)
-                                if query_obj and hasattr(query_obj, "asset") and hasattr(query_obj, "currency"):
-                                    asset_pair = f"{query_obj.asset.lower()}/{query_obj.currency.lower()}"
-                                    query_type_summaries.append(f"{count} {asset_pair}")
-                                else:
-                                    query_type_summaries.append(f"{count} {query_type}")
-                            except Exception:
-                                query_type_summaries.append(f"{count} {query_type}")
-                        else:
-                            query_type_summaries.append(f"{count} {query_type}")
-
-                    console_logger.info(
-                        f"Processing reports from height {current_height}: {', '.join(query_type_summaries)}"
+                    await _flush_new_report_batch(
+                        reports_collections,
+                        current_height,
+                        new_reports_q,
+                        operational_summary,
+                        logger,
+                        reason="batch threshold",
                     )
-
-                    await new_reports_q.put(dict(reports_collections))
-                    reports_collections.clear()
                     last_batch_time = time.time()
 
             except (KeyError, IndexError) as e:
@@ -468,27 +544,14 @@ async def raw_data_queue_handler(
         elif is_agg_report and agg_reports_q is not None:
             # This ensures new reports are processed for disputes even when aggregate arrives at same height
             if len(reports_collections) > 0:
-                # Build query type summary with asset pairs for spot prices
-                query_type_summaries = []
-                for _query_id, reports in reports_collections.items():
-                    query_type = reports[0].query_type
-                    count = len(reports)
-
-                    # For SpotPrice, try to extract asset pair
-                    if query_type.lower() == "spotprice":
-                        try:
-                            query_obj = get_query(reports[0].query_data)
-                            if query_obj and hasattr(query_obj, "asset") and hasattr(query_obj, "currency"):
-                                asset_pair = f"{query_obj.asset.lower()}/{query_obj.currency.lower()}"
-                                query_type_summaries.append(f"{count} {asset_pair}")
-                            else:
-                                query_type_summaries.append(f"{count} {query_type}")
-                        except Exception:
-                            query_type_summaries.append(f"{count} {query_type}")
-                    else:
-                        query_type_summaries.append(f"{count} {query_type}")
-
-                console_logger.info(f"Processing reports from height {current_height}: {', '.join(query_type_summaries)}")
+                await _flush_new_report_batch(
+                    reports_collections,
+                    current_height,
+                    new_reports_q,
+                    operational_summary,
+                    logger,
+                    reason="aggregate report",
+                )
 
             try:
                 height = current_height
@@ -516,33 +579,14 @@ async def raw_data_queue_handler(
 
     # Cleanup: Process any remaining reports before function exits
     if len(reports_collections) > 0:
-        # Build query type summary with asset pairs for spot prices
-        query_type_summaries = []
-        for _query_id, reports in reports_collections.items():
-            query_type = reports[0].query_type
-            count = len(reports)
-
-            # For SpotPrice, try to extract asset pair
-            if query_type.lower() == "spotprice":
-                try:
-                    query_obj = get_query(reports[0].query_data)
-                    if query_obj and hasattr(query_obj, "asset") and hasattr(query_obj, "currency"):
-                        asset_pair = f"{query_obj.asset.lower()}/{query_obj.currency.lower()}"
-                        query_type_summaries.append(f"{count} {asset_pair}")
-                    else:
-                        query_type_summaries.append(f"{count} {query_type}")
-                except Exception:
-                    query_type_summaries.append(f"{count} {query_type}")
-            else:
-                query_type_summaries.append(f"{count} {query_type}")
-
-        collected_height = current_height if current_height is not None else "unknown"
-        console_logger.info(
-            f"Processing remaining reports from height {collected_height} (cleanup): {', '.join(query_type_summaries)}"
+        await _flush_new_report_batch(
+            reports_collections,
+            current_height,
+            new_reports_q,
+            operational_summary,
+            logger,
+            reason="cleanup",
         )
-
-        await new_reports_q.put(dict(reports_collections))
-        reports_collections.clear()
 
 
 async def inspect_reports(
@@ -606,7 +650,7 @@ async def inspect_reports(
         return None
 
     # Branch based on query type - each type has its own inspection path
-    logger.info(f"🔀 Routing to {query_type} inspection path...")
+    logger.debug(f"Routing to {query_type} inspection path")
 
     if query_type.lower() == "spotprice":
         return await inspect_spotprice_path(
@@ -677,7 +721,7 @@ async def inspect_spotprice_path(
 
     # Scenario 3: NOT in config AND NOT in telliot → Foreign query (SKIP)
     if not has_specific_config and not in_telliot:
-        logger.info(f"Foreign query - NOT in config AND NOT in telliot (query: {query_id[:16]}..., asset: {asset_pair})")
+        logger.warning(f"Foreign query - NOT in config AND NOT in telliot (query: {query_id[:16]}..., asset: {asset_pair})")
         description = f"⚠️ **QUERY NOT FOUND IN TELLIOT OR CONFIGS{f' ({asset_pair})' if asset_pair != 'Unknown' else ''}**"
         await send_unsupported_query_alert(
             query_id, query_type, asset_pair, reports[0], logger, description=description, try_decode=True
@@ -686,7 +730,7 @@ async def inspect_spotprice_path(
 
     # Scenario 4: IN config but NOT in telliot → NEW ALERT (SKIP - can't get trusted value)
     elif has_specific_config and not in_telliot:
-        logger.info(f"Query in config but NOT in telliot (query: {query_id[:16]}..., asset: {asset_pair})")
+        logger.warning(f"Query in config but NOT in telliot (query: {query_id[:16]}..., asset: {asset_pair})")
         alert_msg = f"**QueryId:** {query_id}\n"
         alert_msg += f"**QueryType:** {query_type}\n"
         if asset_pair != "Unknown":
@@ -696,20 +740,20 @@ async def inspect_spotprice_path(
         alert_msg += f"**Tx Hash:** {reports[0].tx_hash}\n"
         alert_msg += "**Status:** Cannot inspect - telliot unavailable for trusted value"
 
-        logger.info(f"Config-but-not-telliot alert:\n{alert_msg}")
+        logger.warning(f"Config-but-not-telliot alert:\n{alert_msg}")
         generic_alert(alert_msg, description="🆕 **QUERY IN CONFIG, BUT NOT TELLIOT**")
         return None  # Can't get trusted value from telliot
 
     # Scenario 2: NOT in config but IN telliot → Unconfigured query (PROCEED with global defaults)
     elif not has_specific_config and in_telliot:
-        logger.info(
+        logger.warning(
             f"Query in telliot but NOT in config - proceeding with global defaults "
             f"(query: {query_id[:16]}..., asset: {asset_pair})"
         )
         # Check if this query type typically has per-query configs
         if config_watcher.has_specific_query_configs(query_type):
             # Log info message (don't send Discord alert - we'll alert on value discrepancy if needed)
-            logger.info(
+            logger.warning(
                 f"⚠️ Query found in telliot but not in config file - "
                 f"QueryId: {query_id}, Asset: {asset_pair}, "
                 f"Using global defaults (alert={metrics.alert_threshold}, warning={metrics.warning_threshold})"
@@ -717,7 +761,7 @@ async def inspect_spotprice_path(
         # Fall through to proceed with inspection using global defaults
     else:
         # Scenario 1: IN config AND IN telliot → Normal path (PROCEED)
-        logger.info(f"Normal path - query in config AND telliot (query: {query_id[:16]}..., asset: {asset_pair})")
+        logger.debug(f"Normal path - query in config AND telliot (query: {query_id[:16]}..., asset: {asset_pair})")
 
     # Step 5: Proceed with telliot inspection (for scenarios 1 and 2)
     logger.debug(f"Getting query object and feed for {query_id[:16]}...")
@@ -794,7 +838,7 @@ async def inspect_evmcall_path(
     logger: logging,
 ) -> None:
     """EVMCall inspection path using telliot trusted lookup."""
-    logger.info(f"⚙️ EVMCall inspection - QueryID: {query_id[:16]}...")
+    logger.debug(f"EVMCall inspection - QueryID: {query_id[:16]}...")
     query_type = "evmcall"
 
     # Get query object
@@ -895,8 +939,8 @@ async def inspect_trbbridge_path(
 ) -> None:
     """TRBBridge/TRBBridgeV2 inspection path."""
     label = query_type if query_type else "TRBBridge"
-    logger.info(f"🌉 {label} inspection - QueryID: {query_id[:16]}...")
-    logger.info(f"🔎 Inspecting {len(reports)} {label} report(s)...")
+    logger.debug(f"{label} inspection - QueryID: {query_id[:16]}...")
+    logger.debug(f"Inspecting {len(reports)} {label} report(s)...")
 
     env_var = "TRBBRIDGEV2_CONTRACT_ADDRESS" if query_type.lower() == "trbbridgev2" else "TRBBRIDGE_CONTRACT_ADDRESS"
     return await inspect_trbbridge_reports(reports, disputes_q, query_id, metrics, logger, contract_address_env=env_var)
@@ -927,7 +971,7 @@ async def new_reports_queue_handler(
         reports_processed += sum(len(reports) for reports in new_reports.values())
         if reports_processed >= cache_log_interval:
             cache_stats = await get_price_cache().get_stats()
-            logger.info(
+            logger.debug(
                 f"💾 Price cache stats: {cache_stats['hits']} hits, {cache_stats['misses']} misses, "
                 f"{cache_stats['hit_rate']} hit rate, {cache_stats['size']} entries cached"
             )
@@ -970,7 +1014,7 @@ async def inspect_aggregate_report(
 
     # Get query type from the query object
     query_type = query.__class__.__name__
-    logger.info(f"CONFIG DEBUG: Aggregate report query type determined: {query_type}")
+    logger.debug(f"CONFIG DEBUG: Aggregate report query type determined: {query_type}")
 
     # Check if query type is supported
     if not config_watcher.is_supported_query_type(query_type):

--- a/src/layer_values_monitor/monitor.py
+++ b/src/layer_values_monitor/monitor.py
@@ -94,6 +94,11 @@ def _format_report_batch_summary(reports_collections: dict[str, list[NewReport]]
     return ", ".join(summaries)
 
 
+def _new_report_event_key(height: int, report: NewReport) -> tuple[int, str, str, str, str, str]:
+    """Return a stable key for suppressing duplicate websocket report events."""
+    return (height, report.tx_hash, report.meta_id, report.query_id, report.reporter, report.value)
+
+
 class OperationalSummary:
     """Collect normal-operation report counts and emit periodic summaries."""
 
@@ -427,6 +432,7 @@ async def raw_data_queue_handler(
     """
     iterations = 0
     reports_collections: dict[str, list[NewReport]] = {}
+    seen_new_report_events: set[tuple[int, str, str, str, str, str]] = set()
     # Smart batching configuration
     MAX_BATCH_SIZE = 25  # Process if we hit this many reports
     BATCH_TIMEOUT = 5.0  # Process after 5 seconds regardless
@@ -464,9 +470,6 @@ async def raw_data_queue_handler(
         is_agg_report = "aggregate_report.query_id" in events or "aggregate_report.aggregate_power" in events
 
         if is_new_report:
-            logger.debug(
-                f"Detected new_report event with query_id: {events.get('new_report.query_id', ['unknown'])[0][:16]}"
-            )
             try:
                 # get current height from event
                 height = events["tx.height"][0]
@@ -496,6 +499,7 @@ async def raw_data_queue_handler(
                             logger,
                             reason="height advanced",
                         )
+                        seen_new_report_events.clear()
                         last_batch_time = time.time()
 
                     current_height = height
@@ -505,6 +509,13 @@ async def raw_data_queue_handler(
                 elif current_height is None:
                     current_height = height
                     height_tracker.update(height)
+
+                report_event_key = _new_report_event_key(height, report)
+                if report_event_key in seen_new_report_events:
+                    continue
+
+                seen_new_report_events.add(report_event_key)
+                logger.debug(f"Detected new_report event with query_id: {report.query_id[:16]}")
 
                 # add the current report to the collection (for current height only)
                 reports_collected = reports_collections.get(report.query_id, None)
@@ -535,6 +546,7 @@ async def raw_data_queue_handler(
                         logger,
                         reason="batch threshold",
                     )
+                    seen_new_report_events.clear()
                     last_batch_time = time.time()
 
             except (KeyError, IndexError) as e:
@@ -552,6 +564,7 @@ async def raw_data_queue_handler(
                     logger,
                     reason="aggregate report",
                 )
+                seen_new_report_events.clear()
 
             try:
                 height = current_height
@@ -587,6 +600,7 @@ async def raw_data_queue_handler(
             logger,
             reason="cleanup",
         )
+        seen_new_report_events.clear()
 
 
 async def inspect_reports(

--- a/src/layer_values_monitor/telliot_feeds.py
+++ b/src/layer_values_monitor/telliot_feeds.py
@@ -593,12 +593,10 @@ async def fetch_value(feed: DataFeed) -> OptionalDataPoint:
     except TimeoutError:
         error_msg = "Timeout fetching trusted value from telliot-feeds (15s)"
         logger.warning(error_msg)
-        print(f"Error fetching trusted value from telliot-feeds: {error_msg}")  # print to terminal_log
         return None
     except Exception as e:
         error_msg = f"Error fetching trusted value from telliot-feeds: {e}"
         logger.warning(error_msg)
-        print(error_msg)  # print to terminal_log
         return None
 
 

--- a/tests/test_monitor_regressions.py
+++ b/tests/test_monitor_regressions.py
@@ -39,6 +39,22 @@ def make_spotprice_report() -> NewReport:
     )
 
 
+def test_operational_summary_logs_periodic_report_counts():
+    """Normal report processing should be summarized periodically instead of logged per block."""
+    from layer_values_monitor.monitor import OperationalSummary
+
+    summary = OperationalSummary(interval_seconds=60.0)
+    logger = MagicMock()
+    report = make_spotprice_report()
+
+    summary.last_logged_at = 100.0
+    summary.record_report_batch(123, {report.query_id: [report, report]})
+    summary.maybe_log(logger, now=161.0)
+
+    assert any("Processed 2 reports across 1 heights" in str(call) for call in logger.info.call_args_list)
+    assert summary.report_count == 0
+
+
 @pytest.mark.asyncio
 async def test_inspect_spotprice_path_alerts_on_stale_cache_before_refresh():
     """A stale cached value should still trigger the staleness alert before refresh."""
@@ -204,4 +220,4 @@ async def test_new_reports_queue_handler_counts_actual_reports_for_cache_logging
             except asyncio.CancelledError:
                 pass
 
-    assert any("Price cache stats" in str(call) for call in logger.info.call_args_list)
+    assert any("Price cache stats" in str(call) for call in logger.debug.call_args_list)

--- a/tests/test_queue_handler.py
+++ b/tests/test_queue_handler.py
@@ -360,9 +360,9 @@ async def test_new_report_followed_by_aggregate_same_height(mock_logger):
     assert agg_report.query_id == "83a7f3d48786ac26", "Should be the same query ID"
     assert agg_report.micro_report_height == "116", "Should have correct micro report height"
 
-    # Verify event detection was logged
-    detection_calls = [str(call) for call in mock_logger.info.call_args_list if "Detected new_report event" in str(call)]
-    assert len(detection_calls) > 0, f"Should have logged event detection. Actual calls: {mock_logger.info.call_args_list}"
+    # Verify event detection is still available in debug logs without polluting operational info logs.
+    detection_calls = [str(call) for call in mock_logger.debug.call_args_list if "Detected new_report event" in str(call)]
+    assert len(detection_calls) > 0, f"Should have logged event detection. Actual calls: {mock_logger.debug.call_args_list}"
 
 
 @pytest.mark.asyncio

--- a/tests/test_queue_handler.py
+++ b/tests/test_queue_handler.py
@@ -172,6 +172,67 @@ async def test_raw_data_queue_handler_empty_queue(mock_logger):
 
 
 @pytest.mark.asyncio
+async def test_raw_data_queue_handler_skips_duplicate_new_report_events(mock_logger):
+    """Duplicate websocket report events should not be logged or batched twice."""
+    raw_data_q = asyncio.Queue()
+    new_reports_q = asyncio.Queue()
+
+    duplicate_report = {
+        "result": {
+            "events": {
+                "tx.height": ["100"],
+                "new_report.query_type": ["SpotPrice"],
+                "new_report.query_data": ["0x..."],
+                "new_report.query_id": ["query_id_1"],
+                "new_report.value": ["0x123"],
+                "new_report.aggregate_method": ["median"],
+                "new_report.cyclelist": ["cycle1"],
+                "new_report.reporter_power": ["1000"],
+                "new_report.reporter": ["reporter1"],
+                "new_report.timestamp": ["1625097600000"],
+                "new_report.meta_id": ["meta1"],
+                "tx.hash": ["hash1"],
+            }
+        }
+    }
+    trigger_report = {
+        "result": {
+            "events": {
+                "tx.height": ["101"],
+                "new_report.query_type": ["SpotPrice"],
+                "new_report.query_data": ["0x..."],
+                "new_report.query_id": ["trigger_query_id"],
+                "new_report.value": ["0x456"],
+                "new_report.aggregate_method": ["median"],
+                "new_report.cyclelist": ["cycle1"],
+                "new_report.reporter_power": ["1000"],
+                "new_report.reporter": ["reporter2"],
+                "new_report.timestamp": ["1625097600001"],
+                "new_report.meta_id": ["meta2"],
+                "tx.hash": ["hash2"],
+            }
+        }
+    }
+
+    await raw_data_q.put(duplicate_report)
+    await raw_data_q.put(duplicate_report)
+    await raw_data_q.put(trigger_report)
+
+    height_tracker = HeightTracker()
+    await raw_data_queue_handler(raw_data_q, new_reports_q, None, mock_logger, height_tracker, max_iterations=3)
+
+    first_collection = await new_reports_q.get()
+    assert len(first_collection["query_id_1"]) == 1
+
+    duplicate_detection_calls = [
+        str(call)
+        for call in mock_logger.debug.call_args_list
+        if "Detected new_report event with query_id: query_id_1" in str(call)
+    ]
+    assert len(duplicate_detection_calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_raw_data_queue_handler_sequential_same_height(mock_logger):
     """Test handling multiple reports with the same block height.
 


### PR DESCRIPTION
Currently, the LVM sends logs about detected reports, and debug logs go to local file only. This PR changes logging so that everything goes to standard output. This helps with log retention and rotation because everything gets managed by the systemd journal when the LVM is and installed systemd service for reliable operation. 

The user can set `LVM_ENABLE_FILE_LOGS=true` to output logs to a text files when this is needed.